### PR TITLE
Strongly type customisable traversal components

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.3"
+  "version": "0.0.4"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1200,8 +1200,16 @@
       "version": "7.10.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
       "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
-      "dev": true,
       "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/runtime-corejs3": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
+      "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+      "requires": {
+        "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.4"
       }
     },
@@ -1275,7 +1283,6 @@
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
       "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-      "dev": true,
       "requires": {
         "@emotion/memoize": "0.7.4"
       }
@@ -1283,8 +1290,7 @@
     "@emotion/memoize": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-      "dev": true
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
     "@emotion/stylis": {
       "version": "0.8.5",
@@ -3125,6 +3131,70 @@
         "@types/node": ">= 8"
       }
     },
+    "@popmotion/easing": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@popmotion/easing/-/easing-1.0.2.tgz",
+      "integrity": "sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw=="
+    },
+    "@popmotion/popcorn": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@popmotion/popcorn/-/popcorn-0.4.4.tgz",
+      "integrity": "sha512-jYO/8319fKoNLMlY4ZJPiPu8Ea8occYwRZhxpaNn/kZsK4QG2E7XFlXZMJBsTWDw7I1i0uaqyC4zn1nwEezLzg==",
+      "requires": {
+        "@popmotion/easing": "^1.0.1",
+        "framesync": "^4.0.1",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "^3.1.7",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@redux-saga/core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.1.3.tgz",
+      "integrity": "sha512-8tInBftak8TPzE6X13ABmEtRJGjtK17w7VUs7qV17S8hCO5S3+aUTWZ/DBsBJPdE8Z5jOPwYALyvofgq1Ws+kg==",
+      "requires": {
+        "@babel/runtime": "^7.6.3",
+        "@redux-saga/deferred": "^1.1.2",
+        "@redux-saga/delay-p": "^1.1.2",
+        "@redux-saga/is": "^1.1.2",
+        "@redux-saga/symbols": "^1.1.2",
+        "@redux-saga/types": "^1.1.0",
+        "redux": "^4.0.4",
+        "typescript-tuple": "^2.2.1"
+      }
+    },
+    "@redux-saga/deferred": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/deferred/-/deferred-1.1.2.tgz",
+      "integrity": "sha512-908rDLHFN2UUzt2jb4uOzj6afpjgJe3MjICaUNO3bvkV/kN/cNeI9PMr8BsFXB/MR8WTAZQq/PlTq8Kww3TBSQ=="
+    },
+    "@redux-saga/delay-p": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/delay-p/-/delay-p-1.1.2.tgz",
+      "integrity": "sha512-ojc+1IoC6OP65Ts5+ZHbEYdrohmIw1j9P7HS9MOJezqMYtCDgpkoqB5enAAZrNtnbSL6gVCWPHaoaTY5KeO0/g==",
+      "requires": {
+        "@redux-saga/symbols": "^1.1.2"
+      }
+    },
+    "@redux-saga/is": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/is/-/is-1.1.2.tgz",
+      "integrity": "sha512-OLbunKVsCVNTKEf2cH4TYyNbbPgvmZ52iaxBD4I1fTif4+MTXMa4/Z07L83zW/hTCXwpSZvXogqMqLfex2Tg6w==",
+      "requires": {
+        "@redux-saga/symbols": "^1.1.2",
+        "@redux-saga/types": "^1.1.0"
+      }
+    },
+    "@redux-saga/symbols": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.1.2.tgz",
+      "integrity": "sha512-EfdGnF423glv3uMwLsGAtE6bg+R9MdqlHEzExnfagXPrIiuxwr3bdiAwz3gi+PsrQ3yBlaBpfGLtDG8rf3LgQQ=="
+    },
+    "@redux-saga/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
+    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -3141,6 +3211,128 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@testing-library/jest-dom": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.3.tgz",
+      "integrity": "sha512-vP8ABJt4+YIzu9UItbpJ6nM5zN3g9/tpLcp2DJiXyfX9gnwgcmLsa42+YiohNGEtSUTsseb6xB9HAwlgk8WdaQ==",
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^4.2.2",
+        "chalk": "^3.0.0",
+        "css": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "jest-diff": "^25.1.0",
+        "jest-matcher-utils": "^25.1.0",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "diff-sequences": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+          "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "jest-diff": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+          "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+          "requires": {
+            "chalk": "^3.0.0",
+            "diff-sequences": "^25.2.6",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.5.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig=="
+        },
+        "jest-matcher-utils": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz",
+          "integrity": "sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==",
+          "requires": {
+            "chalk": "^3.0.0",
+            "jest-diff": "^25.5.0",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.5.0"
+          }
+        },
+        "pretty-format": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "requires": {
+            "@jest/types": "^25.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@types/babel__core": {
@@ -3187,8 +3379,7 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
@@ -3215,6 +3406,11 @@
         "@types/node": "*"
       }
     },
+    "@types/history": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.7.tgz",
+      "integrity": "sha512-2xtoL22/3Mv6a70i4+4RB7VgbDDORoWwjcqeNysojZA0R7NK17RbY5Gof/2QiFfJgX+KkWghbwJ+d/2SB8Ndzg=="
+    },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -3228,14 +3424,12 @@
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
-      "dev": true
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
     },
     "@types/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
       "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -3244,7 +3438,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
       "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
@@ -3254,7 +3447,6 @@
       "version": "26.0.7",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.7.tgz",
       "integrity": "sha512-+x0077/LoN6MjqBcVOe1y9dpryWnfDZ+Xfo3EqGeBcfPRJlQp3Lw62RvNlWxuGv7kOEwlHriAa54updi3Jvvwg==",
-      "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",
         "pretty-format": "^25.2.1"
@@ -3264,7 +3456,6 @@
           "version": "25.5.0",
           "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
           "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-          "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
@@ -3275,14 +3466,12 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
@@ -3292,7 +3481,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -3302,7 +3490,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -3310,26 +3497,22 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "diff-sequences": {
           "version": "25.2.6",
           "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
-          "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
-          "dev": true
+          "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg=="
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "jest-diff": {
           "version": "25.5.0",
           "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
           "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
-          "dev": true,
           "requires": {
             "chalk": "^3.0.0",
             "diff-sequences": "^25.2.6",
@@ -3340,14 +3523,12 @@
         "jest-get-type": {
           "version": "25.2.6",
           "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
-          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
-          "dev": true
+          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig=="
         },
         "pretty-format": {
           "version": "25.5.0",
           "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
           "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-          "dev": true,
           "requires": {
             "@jest/types": "^25.5.0",
             "ansi-regex": "^5.0.0",
@@ -3359,7 +3540,6 @@
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -3426,14 +3606,12 @@
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-      "dev": true
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
       "version": "16.9.44",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.44.tgz",
       "integrity": "sha512-BtLoJrXdW8DVZauKP+bY4Kmiq7ubcJq+H/aCpRfvPF7RAT3RwR73Sg8szdc2YasbAlWBDrQ6Q+AFM0KwtQY+WQ==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3469,6 +3647,41 @@
         "redux": "^4.0.0"
       }
     },
+    "@types/react-responsive": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react-responsive/-/react-responsive-8.0.2.tgz",
+      "integrity": "sha512-DTvm3Hb77v0hme7L4GYzRjLQqlZP+zNImFBzdKbSH7CsQ5c7QebGnSQX2Xf3BaA0rm/TQE57eFMhMGLcMe/A9w==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.8.tgz",
+      "integrity": "sha512-HzOyJb+wFmyEhyfp4D4NYrumi+LQgQL/68HvJO+q6XtuHSDvw6Aqov7sCAhjbNq3bUPgPqbdvjXC5HeB2oEAPg==",
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.5.tgz",
+      "integrity": "sha512-ArBM4B1g3BWLGbaGvwBGO75GNFbLDUthrDojV2vHLih/Tq8M+tgvY1DSwkuNrPSwdp/GUL93WSEpTZs8nVyJLw==",
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*",
+        "@types/react-router": "*"
+      }
+    },
+    "@types/react-visibility-sensor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react-visibility-sensor/-/react-visibility-sensor-5.1.0.tgz",
+      "integrity": "sha512-7RaFo0tqqqC4uQtYpiulPIMxjxDPCp3ruxGQr5qxSJivDzhscdK1s9XgKHm9hdlVChTLO7CUgE6Jilw1whSs5g==",
+      "requires": {
+        "react-visibility-sensor": "*"
+      }
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -3495,11 +3708,18 @@
         }
       }
     },
+    "@types/testing-library__jest-dom": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.2.tgz",
+      "integrity": "sha512-K7nUSpH/5i8i0NagTJ+uFUDRueDlnMNhJtMjMwTGPPSqyImbWC/hgKPDCKt6Phu2iMJg2kWqlax+Ucj2DKMwpA==",
+      "requires": {
+        "@types/jest": "*"
+      }
+    },
     "@types/yargs": {
       "version": "15.0.5",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
       "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-      "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -3507,8 +3727,7 @@
     "@types/yargs-parser": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
-      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
-      "dev": true
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "3.7.1",
@@ -3866,6 +4085,15 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -4046,8 +4274,7 @@
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "atob-lite": {
       "version": "2.0.0",
@@ -4066,6 +4293,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
     },
     "babel-jest": {
       "version": "26.1.0",
@@ -5709,6 +5944,11 @@
         }
       }
     },
+    "core-js-pure": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA=="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -5812,6 +6052,32 @@
         "randomfill": "^1.0.3"
       }
     },
+    "css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+      "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+      "requires": {
+        "inherits": "^2.0.4",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "source-map-resolve": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+          "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+          "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0"
+          }
+        }
+      }
+    },
     "css-b64-images": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/css-b64-images/-/css-b64-images-0.2.5.tgz",
@@ -5824,6 +6090,11 @@
       "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
       "dev": true
     },
+    "css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA="
+    },
     "css-to-react-native": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
@@ -5834,6 +6105,11 @@
         "css-color-keywords": "^1.0.0",
         "postcss-value-parser": "^4.0.2"
       }
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
     },
     "cssom": {
       "version": "0.4.4",
@@ -5861,8 +6137,7 @@
     "csstype": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz",
-      "integrity": "sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==",
-      "dev": true
+      "integrity": "sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -5952,7 +6227,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       },
@@ -5960,8 +6234,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -6004,8 +6277,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "dedent": {
       "version": "0.7.0",
@@ -7283,6 +7555,14 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -7313,6 +7593,30 @@
       "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
+      }
+    },
+    "framer-motion": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-2.3.0.tgz",
+      "integrity": "sha512-zX6V5vz3joMzacqV7UpiHKUtqLMmU/YsVM6KpeRCi65KjUiymUX5O2jkpR3cCdlr1DkJ1yWUjBWY7xyiO834VA==",
+      "requires": {
+        "@emotion/is-prop-valid": "^0.8.2",
+        "@popmotion/easing": "^1.0.2",
+        "@popmotion/popcorn": "^0.4.2",
+        "framesync": "^4.0.4",
+        "hey-listen": "^1.0.8",
+        "popmotion": "9.0.0-beta-8",
+        "style-value-types": "^3.1.9",
+        "tslib": "^1.10.0"
+      }
+    },
+    "framesync": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-4.0.4.tgz",
+      "integrity": "sha512-mdP0WvVHe0/qA62KG2LFUAOiWLng5GLpscRlwzBxu2VXOp6B8hNs5C5XlFigsMgrfDrr2YbqTsgdWZTc4RXRMQ==",
+      "requires": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^1.10.0"
       }
     },
     "from2": {
@@ -8098,11 +8402,29 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "hey-listen": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
+    },
     "highlight.js": {
       "version": "10.1.2",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.2.tgz",
       "integrity": "sha512-Q39v/Mn5mfBlMff9r+zzA+gWxRsCRKwEMvYTiisLr/XUiFI/4puWt0Ojdko3R3JCNWGdOWaA5g/Yxqa23kC5AA==",
       "dev": true
+    },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -8119,7 +8441,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
       "requires": {
         "react-is": "^16.7.0"
       }
@@ -8392,6 +8713,11 @@
         }
       }
     },
+    "hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "iconv-lite": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
@@ -8465,8 +8791,7 @@
     "indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
     "infer-owner": {
       "version": "1.0.4",
@@ -8487,8 +8812,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -10637,6 +10961,32 @@
         }
       }
     },
+    "jest-styled-components": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-7.0.2.tgz",
+      "integrity": "sha512-i1Qke8Jfgx0Why31q74ohVj9S2FmMLUE8bNRSoK4DgiurKkXG6HC4NPhcOLAz6VpVd9wXkPn81hOt4aAQedqsA==",
+      "requires": {
+        "css": "^2.2.4"
+      },
+      "dependencies": {
+        "css": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+          "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "source-map": "^0.6.1",
+            "source-map-resolve": "^0.5.2",
+            "urix": "^0.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "jest-util": {
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.1.0.tgz",
@@ -10928,8 +11278,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.14.0",
@@ -11230,8 +11579,7 @@
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
-      "dev": true
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -11262,6 +11610,11 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.set": {
       "version": "4.3.2",
@@ -11304,7 +11657,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -11417,6 +11769,14 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
       "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
       "dev": true
+    },
+    "matchmediaquery": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.3.1.tgz",
+      "integrity": "sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==",
+      "requires": {
+        "css-mediaquery": "^0.1.2"
+      }
     },
     "md5.js": {
       "version": "1.3.5",
@@ -11654,8 +12014,16 @@
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
+    },
+    "mini-create-react-context": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz",
+      "integrity": "sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "tiny-warning": "^1.0.3"
+      }
     },
     "minify": {
       "version": "5.1.1",
@@ -12128,6 +12496,11 @@
       "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
       "dev": true
     },
+    "normalizr": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/normalizr/-/normalizr-3.6.0.tgz",
+      "integrity": "sha512-25cd8DiDu+pL46KIaxtVVvvEPjGacJgv0yUg950evr62dQ/ks2JO1kf7+Vi5/rMFjaSTSTls7aCnmRlUSljtiA=="
+    },
     "npm-bundled": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
@@ -12268,8 +12641,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -12824,6 +13196,19 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "popmotion": {
+      "version": "9.0.0-beta-8",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.0.0-beta-8.tgz",
+      "integrity": "sha512-6eQzqursPvnP7ePvdfPeY4wFHmS3OLzNP8rJRvmfFfEIfpFqrQgLsM50Gd9AOvGKJtYJOFknNG+dsnzCpgIdAA==",
+      "requires": {
+        "@popmotion/easing": "^1.0.1",
+        "@popmotion/popcorn": "^0.4.2",
+        "framesync": "^4.0.4",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "^3.1.6",
+        "tslib": "^1.10.0"
+      }
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -12959,7 +13344,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -13161,8 +13545,7 @@
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-redux": {
       "version": "7.2.1",
@@ -13175,6 +13558,71 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.7.2",
         "react-is": "^16.9.0"
+      }
+    },
+    "react-responsive": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-8.1.0.tgz",
+      "integrity": "sha512-U8Nv2/ZWACIw/fAE9XNPbc2Xo33X5q1bcCASc2SufvJ9ifB+o/rokfogfznSVcvS22hN1rafGi0uZD6GiVFEHw==",
+      "requires": {
+        "hyphenate-style-name": "^1.0.0",
+        "matchmediaquery": "^0.3.0",
+        "prop-types": "^15.6.1",
+        "shallow-equal": "^1.1.0"
+      }
+    },
+    "react-router": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
+    "react-visibility-sensor": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-visibility-sensor/-/react-visibility-sensor-5.1.1.tgz",
+      "integrity": "sha512-cTUHqIK+zDYpeK19rzW6zF9YfT4486TIgizZW53wEZ+/GPBbK7cNS0EHyJVyHYacwFEvvHLEKfgJndbemWhB/w==",
+      "requires": {
+        "prop-types": "^15.7.2"
       }
     },
     "read": {
@@ -13374,7 +13822,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -13384,10 +13831,22 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
       "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
+      }
+    },
+    "redux-devtools-extension": {
+      "version": "2.13.8",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
+      "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
+    },
+    "redux-saga": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.1.3.tgz",
+      "integrity": "sha512-RkSn/z0mwaSa5/xH/hQLo8gNf4tlvT18qXDNvedihLcfzh+jMchDgaariQoehCpgRltEm4zHKJyINEz6aqswTw==",
+      "requires": {
+        "@redux-saga/core": "^1.1.3"
       }
     },
     "regenerate": {
@@ -13408,8 +13867,7 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-      "dev": true
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -13595,6 +14053,11 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
+    },
     "resolve": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -13627,11 +14090,15 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
+    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-      "dev": true
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -13907,6 +14374,11 @@
       "requires": {
         "kind-of": "^6.0.2"
       }
+    },
+    "shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "shallowequal": {
       "version": "1.1.0",
@@ -14209,7 +14681,6 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
-      "dev": true,
       "requires": {
         "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0",
@@ -14239,8 +14710,7 @@
     "source-map-url": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-      "dev": true
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -14553,7 +15023,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
       "requires": {
         "min-indent": "^1.0.0"
       }
@@ -14573,6 +15042,15 @@
         "duplexer": "^0.1.1",
         "minimist": "^1.2.0",
         "through": "^2.3.4"
+      }
+    },
+    "style-value-types": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.1.9.tgz",
+      "integrity": "sha512-050uqgB7WdvtgacoQKm+4EgKzJExVq0sieKBQQtJiU3Muh6MYcCp4T3M8+dfl6VOF2LR0NNwXBP1QYEed8DfIw==",
+      "requires": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^1.10.0"
       }
     },
     "styled-components": {
@@ -14641,8 +15119,7 @@
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -14922,6 +15399,16 @@
         "xtend": "~4.0.1"
       }
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -15083,8 +15570,7 @@
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
-      "dev": true
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "tsutils": {
       "version": "3.17.1",
@@ -15190,6 +15676,27 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
       "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
+    },
+    "typescript-compare": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.2.tgz",
+      "integrity": "sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA==",
+      "requires": {
+        "typescript-logic": "^0.0.0"
+      }
+    },
+    "typescript-logic": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-logic/-/typescript-logic-0.0.0.tgz",
+      "integrity": "sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q=="
+    },
+    "typescript-tuple": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-2.2.1.tgz",
+      "integrity": "sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==",
+      "requires": {
+        "typescript-compare": "^0.0.2"
+      }
     },
     "uglify-js": {
       "version": "3.10.0",
@@ -15419,8 +15926,7 @@
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-      "dev": true
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "url": {
       "version": "0.11.0",
@@ -15510,6 +16016,11 @@
       "requires": {
         "builtins": "^1.0.3"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "docs:serve": "npm run docs && serve typedoc/docs",
     "lint": "eslint ./packages --ext .ts,.tsx",
     "lint-fix": "eslint ./packages --ext .ts,.tsx --fix",
-    "start": "run-p start:**",
+    "start": "run-p \"start:**\"",
     "start:core": "lerna run start --scope @doctorlink/traversal-core --stream",
     "start:redux": "lerna run start --scope @doctorlink/traversal-redux --stream",
     "start:sc": "lerna run start --scope @doctorlink/styled-components --stream",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
       "no-case-declarations": 1,
       "@typescript-eslint/no-empty-interface": 1,
       "@typescript-eslint/no-empty-function": 1,
-      "react/prop-types": 1,
+      "react/prop-types": 0,
       "react/display-name": 1
     }
   },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "docs:serve": "npm run docs && serve typedoc/docs",
     "lint": "eslint ./packages --ext .ts,.tsx",
     "lint-fix": "eslint ./packages --ext .ts,.tsx --fix",
-    "start": "run-p 'start:**'",
+    "start": "run-p start:**",
     "start:core": "lerna run start --scope @doctorlink/traversal-core --stream",
     "start:redux": "lerna run start --scope @doctorlink/traversal-redux --stream",
     "start:sc": "lerna run start --scope @doctorlink/styled-components --stream",

--- a/packages/styled-components/package-lock.json
+++ b/packages/styled-components/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@doctorlink/styled-components",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -30,7 +30,7 @@
     "build": "npm run build:types && npm run build:js",
     "build:types": "tsc --emitDeclarationOnly",
     "build:js": "babel src --out-dir lib --extensions \".ts,.tsx\" --source-maps inline",
-    "start": "run-p 'build:** -- --watch'",
+    "start": "run-p \"build:** -- --watch\"",
     "test": "tsc --noEmit && jest test"
   },
   "dependencies": {

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/styled-components",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Doctorlink styled components",
   "keywords": [
     "styled-components"
@@ -34,8 +34,8 @@
     "test": "tsc --noEmit && jest test"
   },
   "dependencies": {
-    "@doctorlink/traversal-core": "^0.0.3",
-    "@doctorlink/traversal-redux": "^0.0.3",
+    "@doctorlink/traversal-core": "^0.0.4",
+    "@doctorlink/traversal-redux": "^0.0.4",
     "@testing-library/jest-dom": "^5.11.2",
     "@types/react-redux": "^7.1.9",
     "@types/react-responsive": "^8.0.2",

--- a/packages/styled-components/src/ComponentModules/Traversal/Traversal.tsx
+++ b/packages/styled-components/src/ComponentModules/Traversal/Traversal.tsx
@@ -8,6 +8,7 @@ import {
 } from './defaults';
 import { TraversalForm } from './TraversalForm';
 import { TraversalCallbacks } from './TraversalCallbacks';
+import { TraversalComponents } from './TraversalComponents';
 
 const FlexButton = styled.div`
   flex: 1;
@@ -66,7 +67,7 @@ export interface TraversalProps {
   minWidthTable?: number;
   labels?: TraversalLabels;
   actions?: TraversalCallbacks;
-  components?: Partial<typeof defaultTraversalComponents>;
+  components?: Partial<TraversalComponents>;
 }
 
 export const Traversal: React.FC<TraversalProps> = ({

--- a/packages/styled-components/src/ComponentModules/Traversal/TraversalCallbacks.ts
+++ b/packages/styled-components/src/ComponentModules/Traversal/TraversalCallbacks.ts
@@ -1,9 +1,28 @@
+export type UpdateValueCallback = (
+  answerId: string,
+  questionAnswerIds: string[],
+  value: string
+) => void;
+
+export type ToggleRadioCallback = (
+  event: string,
+  answerId: string,
+  questionAnswerIds: string[],
+  checked: boolean
+) => void;
+
+export type ToggleCheckboxCallback = (
+  event: string,
+  answerId: string,
+  questionAnswerIds: string[]
+) => void;
+
 export interface TraversalCallbacks {
   next: () => void;
   previous: () => void;
   showSummary: () => void;
-  showExplanation: (explanation: any) => void;
-  updateValue: (answerId: any, questionAnswerIds: any, value: any) => void;
-  toggleCheckbox: (event: any, answerId: any, questionAnswerIds: any) => void;
-  toggleRadio: (event: any, answerId: any, questionAnswerIds: any) => void;
+  showExplanation: (explanation: string) => void;
+  updateValue: UpdateValueCallback;
+  toggleCheckbox: ToggleCheckboxCallback;
+  toggleRadio: ToggleRadioCallback;
 }

--- a/packages/styled-components/src/ComponentModules/Traversal/TraversalCollection.tsx
+++ b/packages/styled-components/src/ComponentModules/Traversal/TraversalCollection.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { AnimatePresence } from 'framer-motion';
+
+export interface TraversalCollectionProps {
+  mirror: boolean;
+}
+
+export const TraversalCollection: React.FC<TraversalCollectionProps> = ({
+  mirror,
+  children,
+}) => (
+  <AnimatePresence custom={mirror} exitBeforeEnter>
+    {children}
+  </AnimatePresence>
+);

--- a/packages/styled-components/src/ComponentModules/Traversal/TraversalComponents.ts
+++ b/packages/styled-components/src/ComponentModules/Traversal/TraversalComponents.ts
@@ -5,7 +5,7 @@ import {
   FormHTMLAttributes,
   HTMLAttributes,
   RefAttributes,
-} from 'React';
+} from 'react';
 import {
   TraversalQuestionProps,
   InfoIconProps,

--- a/packages/styled-components/src/ComponentModules/Traversal/TraversalComponents.ts
+++ b/packages/styled-components/src/ComponentModules/Traversal/TraversalComponents.ts
@@ -1,0 +1,57 @@
+import { HTMLMotionProps } from 'framer-motion';
+import {
+  ComponentType,
+  ButtonHTMLAttributes,
+  FormHTMLAttributes,
+  HTMLAttributes,
+  RefAttributes,
+} from 'React';
+import {
+  TraversalQuestionProps,
+  InfoIconProps,
+  TableHeaderCellProps,
+  TableAnswerCellProps,
+  SectionProps,
+  RadioProps,
+  CheckboxProps,
+} from '../../Components';
+import {
+  TraversalCheckboxProps,
+  TraversalRadioProps,
+  TraversalValueProps,
+} from './inputs';
+import { TraversalNodesProps } from './TraversalNodes';
+import { TraversalCollectionProps } from './TraversalCollection';
+
+type HTMLComponentType<E> = ComponentType<HTMLAttributes<E> & RefAttributes<E>>;
+
+export interface TraversalComponents {
+  Button: ComponentType<ButtonHTMLAttributes<HTMLButtonElement>>;
+  Form: ComponentType<FormHTMLAttributes<HTMLFormElement>>;
+  AlgoName: HTMLComponentType<HTMLHeadingElement>;
+  ErrorText: HTMLComponentType<HTMLDivElement>;
+  QuestionTitle: HTMLComponentType<HTMLHeadingElement>;
+  Question: ComponentType<TraversalQuestionProps>;
+  InfoIcon: ComponentType<InfoIconProps>;
+  Nodes: ComponentType<TraversalNodesProps>;
+  Fieldset: ComponentType<HTMLMotionProps<'fieldset'>>;
+  Container: HTMLComponentType<HTMLDivElement>;
+  Collection: ComponentType<TraversalCollectionProps>;
+  TableQuestion: ComponentType;
+  HeaderRow: ComponentType;
+  HeaderCell: ComponentType<TableHeaderCellProps>;
+  QuestionRow: HTMLComponentType<HTMLTableRowElement>;
+  AnswerCell: ComponentType<TableAnswerCellProps>;
+  Response: HTMLComponentType<HTMLDivElement>;
+  Section: ComponentType<SectionProps>;
+  Label: HTMLComponentType<HTMLLabelElement>;
+  DisplayText: HTMLComponentType<HTMLDivElement>;
+  Radio: ComponentType<RadioProps>;
+  Checkbox: ComponentType<CheckboxProps>;
+  DateField: HTMLComponentType<HTMLInputElement>;
+  NumberField: HTMLComponentType<HTMLInputElement>;
+  TextField: HTMLComponentType<HTMLInputElement>;
+  TraversalValue: ComponentType<TraversalValueProps>;
+  TraversalRadio: ComponentType<TraversalRadioProps>;
+  TraversalCheckbox: ComponentType<TraversalCheckboxProps>;
+}

--- a/packages/styled-components/src/ComponentModules/Traversal/TraversalForm.tsx
+++ b/packages/styled-components/src/ComponentModules/Traversal/TraversalForm.tsx
@@ -8,6 +8,7 @@ import {
 import { TraversalTable } from './TraversalTable';
 import { TraversalResponse } from './TraversalResponse';
 import { TraversalCallbacks } from './TraversalCallbacks';
+import { TraversalComponents } from './TraversalComponents';
 import { useTraversalScroll } from '../../Hooks';
 
 export interface TraversalFormProps {
@@ -15,7 +16,7 @@ export interface TraversalFormProps {
   containerRef?: MutableRefObject<any>;
   minWidthTable?: number;
   actions?: TraversalCallbacks;
-  components?: Partial<typeof defaultTraversalComponents>;
+  components?: Partial<TraversalComponents>;
 }
 
 export const TraversalForm: React.FC<TraversalFormProps> = ({

--- a/packages/styled-components/src/ComponentModules/Traversal/TraversalNodes.tsx
+++ b/packages/styled-components/src/ComponentModules/Traversal/TraversalNodes.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const transition = {
+  x: { duration: 0.25, ease: 'easeInOut' },
+};
+
+const variants = {
+  enter: (mirror: boolean) => ({
+    opacity: 0,
+    x: mirror === true ? '-100%' : '100%',
+    transition: transition,
+  }),
+  center: {
+    zIndex: 1,
+    opacity: 1,
+    x: '0',
+    transition: transition,
+  },
+  exit: (mirror: boolean) => ({
+    zIndex: 0,
+    opacity: 0,
+    x: mirror === true ? '100%' : '-100%',
+    transition: transition,
+  }),
+};
+
+export interface TraversalNodesProps {
+  mirror: boolean;
+}
+
+export const TraversalNodes: React.FC<TraversalNodesProps> = ({
+  children,
+  mirror,
+}) => (
+  <motion.div
+    variants={variants}
+    custom={mirror}
+    initial="enter"
+    animate="center"
+    exit="exit"
+  >
+    {children}
+  </motion.div>
+);

--- a/packages/styled-components/src/ComponentModules/Traversal/TraversalResponse.tsx
+++ b/packages/styled-components/src/ComponentModules/Traversal/TraversalResponse.tsx
@@ -3,15 +3,23 @@ import {
   defaultTraversalActions,
   defaultTraversalComponents,
 } from './defaults';
-import { TraversalAnswer, TraversalQuestion } from '@doctorlink/traversal-core';
+import {
+  TraversalAnswer,
+  TraversalQuestion,
+  TraversalError,
+} from '@doctorlink/traversal-core';
+import { TraversalCallbacks } from './TraversalCallbacks';
+import { TraversalComponents } from './TraversalComponents';
 
-export const TraversalResponse: React.FC<{
+export interface TraversalResponseProps {
   question: TraversalQuestion;
   answers: Record<string, TraversalAnswer>;
-  error: any;
-  actions?: any;
-  components?: any;
-}> = ({
+  error: TraversalError;
+  actions?: TraversalCallbacks;
+  components?: TraversalComponents;
+}
+
+export const TraversalResponse: React.FC<TraversalResponseProps> = ({
   question,
   answers,
   error,
@@ -32,7 +40,7 @@ export const TraversalResponse: React.FC<{
       {comps.QuestionTitle && question.title && (
         <comps.QuestionTitle>{question.title}</comps.QuestionTitle>
       )}
-      <comps.Question displayText={question.displayText} error={error}>
+      <comps.Question displayText={question.displayText}>
         <comps.InfoIcon
           onClick={actions.showExplanation}
           explanation={question.explanation}
@@ -98,7 +106,6 @@ export const TraversalResponse: React.FC<{
                     />
                   )}
                   <comps.DisplayText
-                    answer={answer}
                     dangerouslySetInnerHTML={{ __html: answer.displayText }}
                   />
                   <comps.InfoIcon

--- a/packages/styled-components/src/ComponentModules/Traversal/TraversalTable.tsx
+++ b/packages/styled-components/src/ComponentModules/Traversal/TraversalTable.tsx
@@ -3,15 +3,25 @@ import {
   defaultTraversalActions,
   defaultTraversalComponents,
 } from './defaults';
+import {
+  TraversalNode,
+  TraversalQuestion,
+  TraversalAnswer,
+  TraversalError,
+} from '@doctorlink/traversal-core';
+import { TraversalCallbacks } from './TraversalCallbacks';
+import { TraversalComponents } from './TraversalComponents';
 
-export const TraversalTable: React.FC<{
-  node: any;
-  questions: any;
-  answers: any;
-  errors: any;
-  actions?: any;
-  components?: any;
-}> = ({
+interface TraversalTableProps {
+  node: TraversalNode;
+  questions: Record<string, TraversalQuestion>;
+  answers: Record<string, TraversalAnswer>;
+  errors: Record<string, TraversalError>;
+  actions?: TraversalCallbacks;
+  components?: TraversalComponents;
+}
+
+export const TraversalTable: React.FC<TraversalTableProps> = ({
   node,
   questions,
   answers,
@@ -23,7 +33,7 @@ export const TraversalTable: React.FC<{
   return (
     <comps.TableQuestion>
       <comps.HeaderRow>
-        {questions[node.questions[0]].answers.map((answerId: any) => (
+        {questions[node.questions[0]].answers.map((answerId) => (
           <comps.HeaderCell
             key={answerId}
             text={answers[answerId].displayText}
@@ -36,7 +46,7 @@ export const TraversalTable: React.FC<{
           </comps.HeaderCell>
         ))}
       </comps.HeaderRow>
-      {node.questions.map((q: any) => {
+      {node.questions.map((q) => {
         const question = questions[q];
         const error = errors[q];
         return (
@@ -52,7 +62,7 @@ export const TraversalTable: React.FC<{
                 explanation={question.explanation}
               />
             </comps.HeaderCell>
-            {question.answers.map((answerId: any) => {
+            {question.answers.map((answerId) => {
               const answer = answers[answerId];
               return (
                 <comps.AnswerCell key={answerId} answerId={answerId}>

--- a/packages/styled-components/src/ComponentModules/Traversal/defaults.tsx
+++ b/packages/styled-components/src/ComponentModules/Traversal/defaults.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
 import styled from 'styled-components';
 
 import QuestionTitle from '../../Components/QuestionTitle';
@@ -23,48 +21,15 @@ import Checkbox from '../../Components/Checkbox';
 import DateField from '../../Components/DateField';
 import NumberField from '../../Components/NumberField';
 import TextField from '../../Components/TextField';
-
 import { TraversalCallbacks } from './TraversalCallbacks';
+import { TraversalComponents } from './TraversalComponents';
+import { TraversalNodes as Nodes } from './TraversalNodes';
+import { TraversalCollection as Collection } from './TraversalCollection';
+import { TraversalCheckbox, TraversalRadio, TraversalValue } from './inputs';
 
 const Button = styled(SimpleButton)`
   width: 100%;
 `;
-
-const transition = {
-  x: { duration: 0.25, ease: 'easeInOut' },
-};
-
-const variants = {
-  enter: (mirror: boolean) => ({
-    opacity: 0,
-    x: mirror === true ? '-100%' : '100%',
-    transition: transition,
-  }),
-  center: {
-    zIndex: 1,
-    opacity: 1,
-    x: '0',
-    transition: transition,
-  },
-  exit: (mirror: boolean) => ({
-    zIndex: 0,
-    opacity: 0,
-    x: mirror === true ? '100%' : '-100%',
-    transition: transition,
-  }),
-};
-
-const Nodes: React.FC<any> = ({ children, mirror }) => (
-  <motion.div
-    variants={variants}
-    custom={mirror}
-    initial="enter"
-    animate="center"
-    exit="exit"
-  >
-    {children}
-  </motion.div>
-);
 
 const Form = styled.form``;
 
@@ -72,58 +37,7 @@ const Container = styled.div`
   transition: all 300ms;
 `;
 
-const Collection: React.FC<{ mirror: boolean }> = ({ mirror, children }) => (
-  <AnimatePresence custom={mirror} exitBeforeEnter>
-    {children}
-  </AnimatePresence>
-);
-
-const TraversalRadio: React.FC<{
-  Comp: any;
-  answerId: any;
-  checked: any;
-  siblingIds: any;
-  action: any;
-}> = ({ Comp, answerId, checked, siblingIds, action }) => (
-  <Comp
-    id={answerId}
-    name={answerId.substring(0, answerId.lastIndexOf('_'))}
-    value={true}
-    checked={checked}
-    onChange={() => {}}
-    onClick={(e: any) => action(e, answerId, siblingIds, true)}
-  />
-);
-
-const TraversalCheckbox: React.FC<{
-  Comp: any;
-  answerId: any;
-  checked: any;
-  siblingIds: any;
-  action: any;
-}> = ({ Comp, answerId, checked, siblingIds, action }) => (
-  <Comp
-    id={answerId}
-    value={true}
-    checked={checked}
-    onChange={(e: any) => action(e, answerId, siblingIds)}
-  />
-);
-
-const TraversalValue: React.FC<{
-  Comp: any;
-  answerId: any;
-  value: any;
-  siblingIds: any;
-  action: any;
-}> = ({ Comp, answerId, value, siblingIds, action }) => (
-  <Comp
-    value={value || ''}
-    onChange={(e: any) => action(answerId, siblingIds, e.target.value)}
-  />
-);
-
-export const defaultTraversalComponents = {
+export const defaultTraversalComponents: TraversalComponents = {
   Button,
   Form,
   AlgoName,
@@ -158,11 +72,8 @@ export const defaultTraversalActions: TraversalCallbacks = {
   next: () => undefined,
   previous: () => undefined,
   showSummary: () => undefined,
-  showExplanation: (_explanation: any) => undefined,
-  updateValue: (_answerId: any, _questionAnswerIds: any, _value: any) =>
-    undefined,
-  toggleCheckbox: (_event: any, _answerId: any, _questionAnswerIds: any) =>
-    undefined,
-  toggleRadio: (_event: any, _answerId: any, _questionAnswerIds: any) =>
-    undefined,
+  showExplanation: () => undefined,
+  updateValue: () => undefined,
+  toggleCheckbox: () => undefined,
+  toggleRadio: () => undefined,
 };

--- a/packages/styled-components/src/ComponentModules/Traversal/inputs/TraversalCheckbox.tsx
+++ b/packages/styled-components/src/ComponentModules/Traversal/inputs/TraversalCheckbox.tsx
@@ -1,0 +1,25 @@
+import React, { ComponentType } from 'react';
+import { CheckboxProps } from '../../../Components/Checkbox';
+import { ToggleCheckboxCallback } from '../TraversalCallbacks';
+
+export interface TraversalCheckboxProps {
+  Comp: ComponentType<CheckboxProps>;
+  answerId: string;
+  checked: boolean | undefined;
+  siblingIds: string[];
+  action: ToggleCheckboxCallback;
+}
+
+export const TraversalCheckbox: React.FC<TraversalCheckboxProps> = ({
+  Comp,
+  answerId,
+  checked,
+  siblingIds,
+  action,
+}) => (
+  <Comp
+    id={answerId}
+    checked={checked}
+    onChange={(e: any) => action(e, answerId, siblingIds)}
+  />
+);

--- a/packages/styled-components/src/ComponentModules/Traversal/inputs/TraversalRadio.tsx
+++ b/packages/styled-components/src/ComponentModules/Traversal/inputs/TraversalRadio.tsx
@@ -1,0 +1,27 @@
+import React, { ComponentType } from 'react';
+import { RadioProps } from '../../../Components/Radio';
+import { ToggleRadioCallback } from '../TraversalCallbacks';
+
+export interface TraversalRadioProps {
+  Comp: ComponentType<RadioProps>;
+  answerId: string;
+  checked: boolean | undefined;
+  siblingIds: string[];
+  action: ToggleRadioCallback;
+}
+
+export const TraversalRadio: React.FC<TraversalRadioProps> = ({
+  Comp,
+  answerId,
+  checked,
+  siblingIds,
+  action,
+}) => (
+  <Comp
+    id={answerId}
+    name={answerId.substring(0, answerId.lastIndexOf('_'))}
+    checked={checked}
+    onChange={() => {}}
+    onClick={(e: any) => action(e, answerId, siblingIds, true)}
+  />
+);

--- a/packages/styled-components/src/ComponentModules/Traversal/inputs/TraversalValue.tsx
+++ b/packages/styled-components/src/ComponentModules/Traversal/inputs/TraversalValue.tsx
@@ -1,0 +1,23 @@
+import React, { ComponentType, InputHTMLAttributes } from 'react';
+import { UpdateValueCallback } from '../TraversalCallbacks';
+
+export interface TraversalValueProps {
+  Comp: ComponentType<InputHTMLAttributes<HTMLInputElement>>;
+  answerId: string;
+  value: string | null | undefined;
+  siblingIds: string[];
+  action: UpdateValueCallback;
+}
+
+export const TraversalValue: React.FC<TraversalValueProps> = ({
+  Comp,
+  answerId,
+  value,
+  siblingIds,
+  action,
+}) => (
+  <Comp
+    value={value || ''}
+    onChange={(e: any) => action(answerId, siblingIds, e.target.value)}
+  />
+);

--- a/packages/styled-components/src/ComponentModules/Traversal/inputs/index.ts
+++ b/packages/styled-components/src/ComponentModules/Traversal/inputs/index.ts
@@ -1,0 +1,3 @@
+export * from './TraversalCheckbox';
+export * from './TraversalRadio';
+export * from './TraversalValue';

--- a/packages/styled-components/src/Components/Checkbox/Checkbox.tsx
+++ b/packages/styled-components/src/Components/Checkbox/Checkbox.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
-import styled from 'styled-components';
+import React, { InputHTMLAttributes } from 'react';
+import styled, { DefaultTheme } from 'styled-components';
 import { defaultTheme } from '../../Theme';
 
 import HiddenInput from '../HiddenInput';
 
 const Icon = styled.svg``;
 
-interface Props {
-  readonly checked: boolean;
+interface StyledCheckboxProps {
+  readonly checked: boolean | undefined;
 }
 
-const StyledCheckbox = styled.div<Props>`
+const StyledCheckbox = styled.div<StyledCheckboxProps>`
   width: ${(props) => props.theme.checkbox.size}px;
   height: ${(props) => props.theme.checkbox.size}px;
   box-sizing: border-box;
@@ -41,7 +41,15 @@ const CheckboxContainer = styled.div`
   vertical-align: middle;
 `;
 
-const Checkbox: React.FC<any> = ({ className, checked, ...props }) => (
+export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
+  theme?: DefaultTheme;
+}
+
+const Checkbox: React.FC<CheckboxProps> = ({
+  className,
+  checked,
+  ...props
+}) => (
   <CheckboxContainer className={className} theme={props.theme}>
     <HiddenInput type="checkbox" checked={checked} {...props} />
     <StyledCheckbox checked={checked} theme={props.theme}>

--- a/packages/styled-components/src/Components/Checkbox/index.ts
+++ b/packages/styled-components/src/Components/Checkbox/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Checkbox';
+export { default, CheckboxProps } from './Checkbox';

--- a/packages/styled-components/src/Components/DateField/DateField.tsx
+++ b/packages/styled-components/src/Components/DateField/DateField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC, InputHTMLAttributes } from 'react';
 import styled from 'styled-components';
 import { defaultTheme } from '../../Theme';
 
@@ -22,8 +22,11 @@ StyledInput.defaultProps = {
   theme: defaultTheme,
 };
 
-const DateField: React.FC<any> = ({ className, checked, ...props }) => (
-  <StyledInput className={className} {...props} />
-);
+const DateField: FC<InputHTMLAttributes<HTMLInputElement>> = ({
+  className,
+  checked,
+  type,
+  ...props
+}) => <StyledInput className={className} {...props} />;
 
 export default DateField;

--- a/packages/styled-components/src/Components/HiddenInput/HiddenInput.ts
+++ b/packages/styled-components/src/Components/HiddenInput/HiddenInput.ts
@@ -1,10 +1,6 @@
 import styled from 'styled-components';
 
-export interface hiddenInputProps {
-  value: any;
-}
-
-const HiddenCheckbox = styled.input<hiddenInputProps>`
+const HiddenCheckbox = styled.input`
   // Hide checkbox visually but remain accessible to screen readers.
   // Source: https://polished.js.org/docs/#hidevisually
   border: 0;

--- a/packages/styled-components/src/Components/InfoIcon/InfoIcon.tsx
+++ b/packages/styled-components/src/Components/InfoIcon/InfoIcon.tsx
@@ -65,17 +65,15 @@ Container.defaultProps = {
   theme: defaultTheme,
 };
 
-const InfoIcon: React.FC<any> = ({
-  onClick,
-  explanation,
-  inline,
-  padRight,
-  ...props
-}) => {
+export interface InfoIconProps {
+  onClick: (explanation: string) => void;
+  explanation: string | null | undefined;
+}
+
+const InfoIcon: React.FC<InfoIconProps> = ({ onClick, explanation }) => {
   if (!explanation || explanation === '' || !onClick) return null;
   return (
     <Container
-      theme={props.theme}
       onClick={(e) => {
         e.preventDefault();
         onClick(explanation);

--- a/packages/styled-components/src/Components/InfoIcon/index.ts
+++ b/packages/styled-components/src/Components/InfoIcon/index.ts
@@ -1,1 +1,1 @@
-export { default } from './InfoIcon';
+export { default, InfoIconProps } from './InfoIcon';

--- a/packages/styled-components/src/Components/NumberField/NumberField.tsx
+++ b/packages/styled-components/src/Components/NumberField/NumberField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { InputHTMLAttributes } from 'react';
 import styled from 'styled-components';
 import { defaultTheme } from '../../Theme';
 
@@ -22,8 +22,11 @@ StyledInput.defaultProps = {
   theme: defaultTheme,
 };
 
-const NumberField: React.FC<any> = ({ className, checked, ...props }) => (
-  <StyledInput className={className} {...props} />
-);
+const NumberField: React.FC<InputHTMLAttributes<HTMLInputElement>> = ({
+  className,
+  checked,
+  type,
+  ...props
+}) => <StyledInput className={className} {...props} />;
 
 export default NumberField;

--- a/packages/styled-components/src/Components/Question/Question.tsx
+++ b/packages/styled-components/src/Components/Question/Question.tsx
@@ -29,7 +29,11 @@ DisplayText.defaultProps = {
   theme: defaultTheme,
 };
 
-const TraversalQuestion: React.FC<{ displayText: any }> = ({
+export interface TraversalQuestionProps {
+  displayText: string;
+}
+
+const TraversalQuestion: React.FC<TraversalQuestionProps> = ({
   displayText,
   children,
 }) => {

--- a/packages/styled-components/src/Components/Question/index.ts
+++ b/packages/styled-components/src/Components/Question/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Question';
+export { default, TraversalQuestionProps } from './Question';

--- a/packages/styled-components/src/Components/Radio/Radio.tsx
+++ b/packages/styled-components/src/Components/Radio/Radio.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
-import styled from 'styled-components';
+import React, { InputHTMLAttributes } from 'react';
+import styled, { DefaultTheme } from 'styled-components';
 import { defaultTheme } from '../../Theme';
 
 import HiddenInput from '../HiddenInput';
 
 const Icon = styled.svg``;
 
-interface Props {
-  checked: boolean;
+interface StyledRadioProps {
+  checked: boolean | undefined;
 }
 
-const StyledRadio = styled.div<Props>`
+const StyledRadio = styled.div<StyledRadioProps>`
   width: ${(props) => props.theme.radio.size}px;
   height: ${(props) => props.theme.radio.size}px;
   border-radius: ${(props) => props.theme.radio.size / 2}px;
@@ -41,7 +41,11 @@ const RadioContainer = styled.div`
   vertical-align: middle;
 `;
 
-const Radio: React.FC<any> = ({ className, checked, ...props }) => (
+export interface RadioProps extends InputHTMLAttributes<HTMLInputElement> {
+  theme?: DefaultTheme;
+}
+
+const Radio: React.FC<RadioProps> = ({ className, checked, ...props }) => (
   <RadioContainer className={className} theme={props.theme}>
     <HiddenInput type="radio" checked={checked} {...props} />
     <StyledRadio checked={checked} theme={props.theme}>

--- a/packages/styled-components/src/Components/Radio/index.ts
+++ b/packages/styled-components/src/Components/Radio/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Radio';
+export { default, RadioProps } from './Radio';

--- a/packages/styled-components/src/Components/Section/Section.tsx
+++ b/packages/styled-components/src/Components/Section/Section.tsx
@@ -7,7 +7,11 @@ const Text = styled.div`
   padding: 10px;
 `;
 
-export const Section: React.FC<{ text: any }> = ({ text }) =>
-  text && <Text>{text}</Text>;
+export interface SectionProps {
+  text: string;
+}
+
+export const Section: React.FC<SectionProps> = ({ text }) =>
+  text ? <Text>{text}</Text> : null;
 
 export default Section;

--- a/packages/styled-components/src/Components/Section/index.ts
+++ b/packages/styled-components/src/Components/Section/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Section';
+export { default, SectionProps } from './Section';

--- a/packages/styled-components/src/Components/TableAnswerCell/TableAnswerCell.tsx
+++ b/packages/styled-components/src/Components/TableAnswerCell/TableAnswerCell.tsx
@@ -21,7 +21,11 @@ const Label = styled.label`
   cursor: pointer;
 `;
 
-export const TableAnswerCell: React.FC<{ answerId: any }> = ({
+export interface TableAnswerCellProps {
+  answerId: string;
+}
+
+export const TableAnswerCell: React.FC<TableAnswerCellProps> = ({
   answerId,
   children,
 }) => (

--- a/packages/styled-components/src/Components/TableAnswerCell/index.ts
+++ b/packages/styled-components/src/Components/TableAnswerCell/index.ts
@@ -1,1 +1,1 @@
-export { default } from './TableAnswerCell';
+export { default, TableAnswerCellProps } from './TableAnswerCell';

--- a/packages/styled-components/src/Components/TableHeaderCell/TableHeaderCell.tsx
+++ b/packages/styled-components/src/Components/TableHeaderCell/TableHeaderCell.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import styled from 'styled-components';
+import { TraversalError } from '@doctorlink/traversal-core';
 import { defaultTheme } from '../../Theme';
 
-interface Props {
+interface ContainerProps {
   textAlign: string;
-  justifyContent: string;
+  justifyContent?: string;
 }
 
-const Container = styled.div<Props>`
+const Container = styled.div<ContainerProps>`
   display: flex;
   justify-content: ${(props) => props.justifyContent || 'flex-start'};
   text-align: ${(p) => p.textAlign};
@@ -51,13 +52,22 @@ ErrorText.defaultProps = {
   theme: defaultTheme,
 };
 
-const TableHeaderCell: React.FC<{
-  text: any;
-  error: any;
-  justifyContent: any;
-  textAlign: any;
-  colspan: any;
-}> = ({ text, error, justifyContent, textAlign, colspan, children }) => (
+export interface TableHeaderCellProps {
+  text: string;
+  error?: TraversalError;
+  colspan?: number;
+  textAlign?: string;
+  justifyContent?: string;
+}
+
+const TableHeaderCell: React.FC<TableHeaderCellProps> = ({
+  text,
+  error,
+  justifyContent,
+  textAlign = 'center',
+  colspan = 1,
+  children,
+}) => (
   <th colSpan={colspan}>
     <Container textAlign={textAlign} justifyContent={justifyContent}>
       <DisplayText dangerouslySetInnerHTML={{ __html: text }} />
@@ -66,10 +76,5 @@ const TableHeaderCell: React.FC<{
     {error && <ErrorText>{error.text}</ErrorText>}
   </th>
 );
-
-TableHeaderCell.defaultProps = {
-  colspan: 1,
-  textAlign: 'center',
-};
 
 export default TableHeaderCell;

--- a/packages/styled-components/src/Components/TableHeaderCell/index.ts
+++ b/packages/styled-components/src/Components/TableHeaderCell/index.ts
@@ -1,1 +1,1 @@
-export { default } from './TableHeaderCell';
+export { default, TableHeaderCellProps } from './TableHeaderCell';

--- a/packages/styled-components/src/Components/index.ts
+++ b/packages/styled-components/src/Components/index.ts
@@ -26,20 +26,26 @@ export { default as DisplayText } from './DisplayText';
 export { default as AlgoName } from './AlgoName';
 export { default as BodyContent } from './BodyContent';
 export { default as Button } from './Button';
-export { default as Checkbox } from './Checkbox';
+export { default as Checkbox, CheckboxProps } from './Checkbox';
 export { default as DateField } from './DateField';
 export { default as Fieldset } from './Fieldset';
 export { default as GlobalStyle } from './GlobalStyle';
-export { default as InfoIcon } from './InfoIcon';
+export { default as InfoIcon, InfoIconProps } from './InfoIcon';
 export { default as Label } from './Label';
 export { default as NumberField } from './NumberField';
-export { default as Question } from './Question';
+export { default as Question, TraversalQuestionProps } from './Question';
 export { default as QuestionTitle } from './QuestionTitle';
-export { default as Radio } from './Radio';
+export { default as Radio, RadioProps } from './Radio';
 export { default as Response } from './Response';
-export { default as Section } from './Section';
-export { default as TableAnswerCell } from './TableAnswerCell';
-export { default as TableHeaderCell } from './TableHeaderCell';
+export { default as Section, SectionProps } from './Section';
+export {
+  default as TableAnswerCell,
+  TableAnswerCellProps,
+} from './TableAnswerCell';
+export {
+  default as TableHeaderCell,
+  TableHeaderCellProps,
+} from './TableHeaderCell';
 export { default as TableHeaderRow } from './TableHeaderRow';
 export { default as TableQuestion } from './TableQuestion';
 export { default as TableQuestionRow } from './TableQuestionRow';

--- a/packages/traversal-core/package-lock.json
+++ b/packages/traversal-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-core",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/traversal-core/package.json
+++ b/packages/traversal-core/package.json
@@ -27,7 +27,7 @@
     "build": "npm run build:types && npm run build:js",
     "build:types": "tsc --emitDeclarationOnly",
     "build:js": "babel src --out-dir lib --extensions \".ts,.tsx\" --source-maps inline",
-    "start": "run-p 'build:** -- --watch'",
+    "start": "run-p build:** -- --watch",
     "test": "tsc --noEmit && jest test"
   },
   "dependencies": {

--- a/packages/traversal-core/package.json
+++ b/packages/traversal-core/package.json
@@ -27,7 +27,7 @@
     "build": "npm run build:types && npm run build:js",
     "build:types": "tsc --emitDeclarationOnly",
     "build:js": "babel src --out-dir lib --extensions \".ts,.tsx\" --source-maps inline",
-    "start": "run-p build:** -- --watch",
+    "start": "run-p \"build:** -- --watch\"",
     "test": "tsc --noEmit && jest test"
   },
   "dependencies": {

--- a/packages/traversal-core/package.json
+++ b/packages/traversal-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-core",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Doctorlink traversal core package",
   "author": "DoctorLink Team <ben.redmond-benham@doctorlink.com>",
   "homepage": "https://github.com/DoctorLink/npm#readme",

--- a/packages/traversal-embed/package.json
+++ b/packages/traversal-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-embed",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Doctorlink's embeded traversal client",
   "keywords": [
     "doctorlink",
@@ -33,8 +33,8 @@
     "serve": "npm run build && serve ."
   },
   "dependencies": {
-    "@doctorlink/styled-components": "^0.0.3",
-    "@doctorlink/traversal-core": "^0.0.3",
-    "@doctorlink/traversal-redux": "^0.0.3"
+    "@doctorlink/styled-components": "^0.0.4",
+    "@doctorlink/traversal-core": "^0.0.4",
+    "@doctorlink/traversal-redux": "^0.0.4"
   }
 }

--- a/packages/traversal-redux/package-lock.json
+++ b/packages/traversal-redux/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-redux",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/traversal-redux/package.json
+++ b/packages/traversal-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-redux",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Doctorlink traversal redux package",
   "author": "DoctorLink Team <ben.redmond-benham@doctorlink.com>",
   "homepage": "https://github.com/DoctorLink/npm#readme",
@@ -31,7 +31,7 @@
     "test": "tsc --noEmit && jest test"
   },
   "dependencies": {
-    "@doctorlink/traversal-core": "^0.0.3",
+    "@doctorlink/traversal-core": "^0.0.4",
     "axios": "^0.19.2",
     "normalizr": "^3.6.0",
     "redux": "^4.0.5",

--- a/packages/traversal-redux/package.json
+++ b/packages/traversal-redux/package.json
@@ -27,7 +27,7 @@
     "build": "npm run build:types && npm run build:js",
     "build:types": "tsc --emitDeclarationOnly",
     "build:js": "babel src --out-dir lib --extensions \".ts,.tsx\" --source-maps inline",
-    "start": "run-p 'build:** -- --watch'",
+    "start": "run-p build:** -- --watch",
     "test": "tsc --noEmit && jest test"
   },
   "dependencies": {

--- a/packages/traversal-redux/package.json
+++ b/packages/traversal-redux/package.json
@@ -27,7 +27,7 @@
     "build": "npm run build:types && npm run build:js",
     "build:types": "tsc --emitDeclarationOnly",
     "build:js": "babel src --out-dir lib --extensions \".ts,.tsx\" --source-maps inline",
-    "start": "run-p build:** -- --watch",
+    "start": "run-p \"build:** -- --watch\"",
     "test": "tsc --noEmit && jest test"
   },
   "dependencies": {


### PR DESCRIPTION
Strongly type the `components` prop of the `Traversal` component module. It turns out the previous approach of declaring it as `Partial<typeof defaultTraversalComponents>`, which was a quick hack on my part, was painful if you actually tried to use it in a TypeScript app.

NB I haven't done the same to other component modules (Chat etc.), but they will need doing at some point.