### PR TITLE
Bug/1551 summary date format

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.7.0"
+  "version": "0.7.1"
 }

--- a/packages/styled-components/package-lock.json
+++ b/packages/styled-components/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@doctorlink/styled-components",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/styled-components",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Doctorlink styled components",
   "keywords": [
     "styled-components"
@@ -34,8 +34,8 @@
     "test": "tsc --noEmit && jest test"
   },
   "dependencies": {
-    "@doctorlink/traversal-core": "^0.7.0",
-    "@doctorlink/traversal-redux": "^0.7.0",
+    "@doctorlink/traversal-core": "^0.7.1",
+    "@doctorlink/traversal-redux": "^0.7.1",
     "@testing-library/jest-dom": "^5.11.2",
     "@types/react-redux": "^7.1.9",
     "@types/react-responsive": "^8.0.2",

--- a/packages/styled-components/src/ComponentModules/Summary/Summary.tsx
+++ b/packages/styled-components/src/ComponentModules/Summary/Summary.tsx
@@ -80,8 +80,8 @@ export const Summary: React.FC<{
                         .filter((x) => x.isAnswered)
                         .map((answer) => {
                           let answerValue = '';
-                          if (answer.value && answer.type === 85) {
-                            answerValue = new Intl.DateTimeFormat('en-US').format(Date.parse(answer.value))  + ' ';
+                          if (answer.value && answer.nodeType === "DateEnter") {
+                            answerValue = answer.value.toLocaleDateString()  + ' ';
                           }
                           else if (answer.value) {
                             answerValue = answer.value + ' ';

--- a/packages/styled-components/src/ComponentModules/Summary/Summary.tsx
+++ b/packages/styled-components/src/ComponentModules/Summary/Summary.tsx
@@ -78,16 +78,24 @@ export const Summary: React.FC<{
                     <comps.Answers>
                       {question.answers
                         .filter((x) => x.isAnswered)
-                        .map((answer) => (
+                        .map((answer) => {
+                          let answerValue = '';
+                          if (answer.value && answer.type === 85) {
+                            answerValue = new Intl.DateTimeFormat('en-US').format(Date.parse(answer.value))  + ' ';
+                          }
+                          else if (answer.value) {
+                            answerValue = answer.value + ' ';
+                          }
+                          return (
                           <comps.AnswerText
                             key={`${question.algoId}_${question.nodeId}_${answer.answerId}`}
                             dangerouslySetInnerHTML={{
                               __html: `${
-                                answer.value ? answer.value + ' ' : ''
+                                answerValue
                               }${answer.displayText}`,
                             }}
                           />
-                        ))}
+                        )})}
                       {question.answers.filter((x) => x.isAnswered).length ===
                         0 &&
                         question.answers.filter((x) => x.answerId === 0)

--- a/packages/styled-components/src/ComponentModules/Summary/Summary.tsx
+++ b/packages/styled-components/src/ComponentModules/Summary/Summary.tsx
@@ -80,8 +80,9 @@ export const Summary: React.FC<{
                         .filter((x) => x.isAnswered)
                         .map((answer) => {
                           let answerValue = '';
-                          if (answer.value && answer.nodeType === "DateEnter") {
-                            answerValue = (new Intl.DateTimeFormat().format(Date.parse(answer.value))).toString()  + ' ';
+                          if (answer.value && answer.nodeType === 'DateEnter') {
+                            answerValue = (new Intl.DateTimeFormat()
+                            .format(Date.parse(answer.value))).toString()  + ' ';
                           }
                           else if (answer.value) {
                             answerValue = answer.value + ' ';
@@ -90,9 +91,7 @@ export const Summary: React.FC<{
                           <comps.AnswerText
                             key={`${question.algoId}_${question.nodeId}_${answer.answerId}`}
                             dangerouslySetInnerHTML={{
-                              __html: `${
-                                answerValue
-                              }${answer.displayText}`,
+                              __html: `${answerValue}${answer.displayText}`,
                             }}
                           />
                         )})}

--- a/packages/styled-components/src/ComponentModules/Summary/Summary.tsx
+++ b/packages/styled-components/src/ComponentModules/Summary/Summary.tsx
@@ -81,7 +81,7 @@ export const Summary: React.FC<{
                         .map((answer) => {
                           let answerValue = '';
                           if (answer.value && answer.nodeType === "DateEnter") {
-                            answerValue = answer.value.toLocaleDateString()  + ' ';
+                            answerValue = (new Intl.DateTimeFormat().format(Date.parse(answer.value))).toString()  + ' ';
                           }
                           else if (answer.value) {
                             answerValue = answer.value + ' ';

--- a/packages/styled-components/src/ComponentModules/Summary/Summary.tsx
+++ b/packages/styled-components/src/ComponentModules/Summary/Summary.tsx
@@ -81,20 +81,22 @@ export const Summary: React.FC<{
                         .map((answer) => {
                           let answerValue = '';
                           if (answer.value && answer.nodeType === 'DateEnter') {
-                            answerValue = (new Intl.DateTimeFormat()
-                            .format(Date.parse(answer.value))).toString()  + ' ';
-                          }
-                          else if (answer.value) {
+                            answerValue =
+                              new Intl.DateTimeFormat()
+                                .format(Date.parse(answer.value))
+                                .toString() + ' ';
+                          } else if (answer.value) {
                             answerValue = answer.value + ' ';
                           }
                           return (
-                          <comps.AnswerText
-                            key={`${question.algoId}_${question.nodeId}_${answer.answerId}`}
-                            dangerouslySetInnerHTML={{
-                              __html: `${answerValue}${answer.displayText}`,
-                            }}
-                          />
-                        )})}
+                            <comps.AnswerText
+                              key={`${question.algoId}_${question.nodeId}_${answer.answerId}`}
+                              dangerouslySetInnerHTML={{
+                                __html: `${answerValue}${answer.displayText}`,
+                              }}
+                            />
+                          );
+                        })}
                       {question.answers.filter((x) => x.isAnswered).length ===
                         0 &&
                         question.answers.filter((x) => x.answerId === 0)

--- a/packages/traversal-core/package-lock.json
+++ b/packages/traversal-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/traversal-core/package.json
+++ b/packages/traversal-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Doctorlink traversal core package",
   "author": "DoctorLink Team <ben.redmond-benham@doctorlink.com>",
   "homepage": "https://github.com/DoctorLink/npm#readme",

--- a/packages/traversal-core/src/Models/Summary.ts
+++ b/packages/traversal-core/src/Models/Summary.ts
@@ -11,6 +11,8 @@ export interface SummaryQuestion {
   displayText: string;
   summaryText: string;
   clinicalText: string;
+  nodeType: string;
+  nodeTypeId: number;
   answers: SummaryAnswer[];
 }
 
@@ -21,7 +23,8 @@ export interface SummaryAnswer {
   groupId: number;
   nodeId: number;
   assetId: number;
-  nodeType: number;
+  nodeType: string;
+  nodeTypeId: number;
   answerId: number;
   nextNodeId: number;
   value: string | null;

--- a/packages/traversal-embed/package.json
+++ b/packages/traversal-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-embed",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Doctorlink's embeded traversal client",
   "keywords": [
     "doctorlink",
@@ -33,8 +33,8 @@
     "serve": "npm run build && serve ."
   },
   "dependencies": {
-    "@doctorlink/styled-components": "^0.7.0",
-    "@doctorlink/traversal-core": "^0.7.0",
-    "@doctorlink/traversal-redux": "^0.7.0"
+    "@doctorlink/styled-components": "^0.7.1",
+    "@doctorlink/traversal-core": "^0.7.1",
+    "@doctorlink/traversal-redux": "^0.7.1"
   }
 }

--- a/packages/traversal-redux/package-lock.json
+++ b/packages/traversal-redux/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-redux",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/traversal-redux/package.json
+++ b/packages/traversal-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-redux",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Doctorlink traversal redux package",
   "author": "DoctorLink Team <ben.redmond-benham@doctorlink.com>",
   "homepage": "https://github.com/DoctorLink/npm#readme",
@@ -31,7 +31,7 @@
     "test": "tsc --noEmit && jest test"
   },
   "dependencies": {
-    "@doctorlink/traversal-core": "^0.7.0",
+    "@doctorlink/traversal-core": "^0.7.1",
     "axios": "^0.19.2",
     "normalizr": "^3.6.0",
     "redux": "^4.0.5",


### PR DESCRIPTION
Presented question summary was displaying dates in iso format.  Changed it to a localised format. 

This could be extended later, if this format is insufficient.  However, this would require the `culture` of the content (this can be obtained from the Language model of the content.) 

To more thoroughly format the dates, maybe use something like: 

``` js
if (answer.nodeType === "DateEnter") {
  new Intl.DateTimeFormat("en-GB", {
    year: "numeric",
    month: "long",
    day: "2-digit"
  }).format(answer.value)
}
```
As above, this requires the content culture from the release to be on the front-end, which would take more work.