### PR TITLE
#1348: Modal header theme

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.7.2"
+  "version": "0.8.0"
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@typescript-eslint/eslint-plugin": "^3.7.1",
     "@typescript-eslint/parser": "^3.7.1",
     "babel-jest": "^26.1.0",
+    "babel-plugin-styled-components": "^1.11.1",
     "babelify": "^10.0.0",
     "browserify": "^16.5.2",
     "envify": "^4.1.0",

--- a/packages/styled-components/.babelrc
+++ b/packages/styled-components/.babelrc
@@ -1,1 +1,9 @@
-{ "extends": "../../.babelrc", "presets": ["@babel/preset-react"] }
+{
+  "extends": "../../.babelrc",
+  "presets": [
+    "@babel/preset-react"
+  ],
+  "plugins": [
+    "babel-plugin-styled-components"
+  ]
+}

--- a/packages/styled-components/package-lock.json
+++ b/packages/styled-components/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@doctorlink/styled-components",
-	"version": "0.7.2",
+	"version": "0.8.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/styled-components",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Doctorlink styled components",
   "keywords": [
     "styled-components"
@@ -34,8 +34,8 @@
     "test": "tsc --noEmit && jest test"
   },
   "dependencies": {
-    "@doctorlink/traversal-core": "^0.7.2",
-    "@doctorlink/traversal-redux": "^0.7.2",
+    "@doctorlink/traversal-core": "^0.8.0",
+    "@doctorlink/traversal-redux": "^0.8.0",
     "@testing-library/jest-dom": "^5.11.2",
     "@types/react-redux": "^7.1.9",
     "@types/react-responsive": "^8.0.2",

--- a/packages/styled-components/src/ComponentModules/Modal/BackDrop.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/BackDrop.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import styled from 'styled-components';
+
+const BackDropMotion = styled(motion.div)`
+  background-color: rgba(0, 0, 0, 0.8);
+  position: fixed;
+  top: 0;
+  height: 100%;
+  right: 0;
+  width: 100%;
+  z-index: 100;
+`;
+
+export const BackDrop: React.FC = ({ children }) => (
+  <BackDropMotion
+    variants={{
+      enter: {
+        opacity: 1,
+        transition: {
+          default: { duration: 0.15 },
+        },
+      },
+      exit: {
+        opacity: 0,
+        transition: {
+          default: { duration: 0.15 },
+        },
+      },
+    }}
+    initial="exit"
+    animate="enter"
+    exit="exit"
+  >
+    {children}
+  </BackDropMotion>
+);

--- a/packages/styled-components/src/ComponentModules/Modal/Body.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/Body.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+import { defaultTheme } from '../../Theme';
+
+export const Body = styled.div`
+  padding: ${(p) => p.theme.modal.padding}px;
+`;
+
+Body.defaultProps = {
+  theme: defaultTheme,
+};

--- a/packages/styled-components/src/ComponentModules/Modal/Close.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/Close.tsx
@@ -1,15 +1,20 @@
 import React from 'react';
 import styled from 'styled-components';
+import { defaultTheme } from '../../Theme';
 
 const Icon = styled.svg`
   fill: none;
-  stroke: black;
+  stroke: ${(p) => p.theme.modal.header.closeIconColor};
   stroke-width: 2px;
   stroke-linecap: round;
   stroke-linejoin: round;
   cursor: pointer;
   width: 24px;
 `;
+
+Icon.defaultProps = {
+  theme: defaultTheme,
+};
 
 export interface CloseProps {
   onClick: () => void;

--- a/packages/styled-components/src/ComponentModules/Modal/Close.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/Close.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Icon = styled.svg`
+  fill: none;
+  stroke: black;
+  stroke-width: 2px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  cursor: pointer;
+  width: 24px;
+`;
+
+export interface CloseProps {
+  onClick: () => void;
+}
+
+export const Close: React.FC<CloseProps> = ({ onClick }) => (
+  <Icon viewBox="0 0 24 24" onClick={onClick}>
+    <line x1="18" y1="6" x2="6" y2="18"></line>
+    <line x1="6" y1="6" x2="18" y2="18"></line>
+  </Icon>
+);

--- a/packages/styled-components/src/ComponentModules/Modal/Container.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/Container.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  white-space: normal;
+  cursor: auto;
+  width: 100%;
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  margin: 0 auto;
+  text-align: left;
+`;

--- a/packages/styled-components/src/ComponentModules/Modal/Header.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/Header.tsx
@@ -1,6 +1,16 @@
 import styled from 'styled-components';
+import { defaultTheme } from '../../Theme';
 
 export const Header = styled.div`
   display: flex;
-  align-items: flex-start;
+  align-items: center;
+  padding: ${(p) => p.theme.modal.padding}px;
+  background: ${(p) => p.theme.modal.header.background};
+  color: ${(p) => p.theme.modal.header.color};
+  border-top-left-radius: ${(p) => p.theme.modal.borderRadius}px;
+  border-top-right-radius: ${(p) => p.theme.modal.borderRadius}px;
 `;
+
+Header.defaultProps = {
+  theme: defaultTheme,
+};

--- a/packages/styled-components/src/ComponentModules/Modal/Header.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/Header.tsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const Header = styled.div`
+  display: flex;
+  align-items: flex-start;
+`;

--- a/packages/styled-components/src/ComponentModules/Modal/Modal.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/Modal.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useRef } from 'react';
 import { replaceLineBreaks } from '@doctorlink/traversal-core';
 import { defaultModalActions, defaultModalComponents } from './defaults';
+import { ModalModel } from '@doctorlink/traversal-core';
+import { ModalCallbacks } from './ModalCallbacks';
+import { ModalComponents } from './ModalComponents';
 
 export const Modal: React.FC<{
-  modal: any;
-  actions?: any;
-  components?: any;
-  children?: any;
+  modal: ModalModel | null;
+  actions?: ModalCallbacks;
+  components?: ModalComponents;
 }> = ({
   modal,
   children,
@@ -14,20 +16,20 @@ export const Modal: React.FC<{
   components = defaultModalComponents,
 }) => {
   const comps = { ...defaultModalComponents, ...components };
-  const ref = useRef<HTMLElement>();
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const handleClickOutside = (event: any) => {
+    const handleClickOutside = (event: MouseEvent) => {
       if (
         ref &&
         ref.current &&
-        !ref.current.contains(event.target) &&
+        !ref.current.contains(event.target as HTMLElement) &&
         window.innerWidth - event.screenX > 20
       )
         actions.close();
     };
 
-    const handleKeydown = (event: any) => {
+    const handleKeydown = (event: KeyboardEvent) => {
       if (event.keyCode === 27) actions.close();
     };
     document.addEventListener('mousedown', handleClickOutside);
@@ -49,7 +51,7 @@ export const Modal: React.FC<{
         <comps.TransparentCurtain key="curtain">
           <comps.Wrap>
             <comps.Container>
-              <comps.Modal ref={ref}>
+              <comps.ModalWindow ref={ref}>
                 <comps.Header>
                   <comps.Title>{modal.title}</comps.Title>
                   <comps.Close onClick={actions.close} />
@@ -62,7 +64,7 @@ export const Modal: React.FC<{
                   />
                 )}
                 {!modal.content && <comps.Body>{children}</comps.Body>}
-              </comps.Modal>
+              </comps.ModalWindow>
             </comps.Container>
           </comps.Wrap>
         </comps.TransparentCurtain>,

--- a/packages/styled-components/src/ComponentModules/Modal/Modal.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/Modal.tsx
@@ -45,7 +45,7 @@ export const Modal: React.FC<{
     <comps.Wrapper>
       {modal && [
         <comps.DelayExit key="global">
-          <comps.BodyOverflowHidden />
+          <comps.GlobalStyle />
         </comps.DelayExit>,
         <comps.BackDrop key="backdrop" />,
         <comps.TransparentCurtain key="curtain">

--- a/packages/styled-components/src/ComponentModules/Modal/ModalComponents.ts
+++ b/packages/styled-components/src/ComponentModules/Modal/ModalComponents.ts
@@ -1,0 +1,19 @@
+import { ComponentType, HTMLAttributes, RefAttributes } from 'react';
+import { DelayExitProps } from '../../Components/DelayExit';
+import { GlobalStyleComponent, DefaultTheme } from 'styled-components';
+import { CloseProps } from './Close';
+
+export interface ModalComponents {
+  Wrapper: ComponentType;
+  DelayExit: ComponentType<DelayExitProps>;
+  GlobalStyle: GlobalStyleComponent<unknown, DefaultTheme>;
+  TransparentCurtain: ComponentType;
+  BackDrop: ComponentType;
+  Wrap: ComponentType;
+  Container: ComponentType;
+  ModalWindow: ComponentType<RefAttributes<HTMLDivElement>>;
+  Header: ComponentType;
+  Title: ComponentType;
+  Close: ComponentType<CloseProps>;
+  Body: ComponentType<HTMLAttributes<HTMLElement>>;
+}

--- a/packages/styled-components/src/ComponentModules/Modal/ModalWindow.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/ModalWindow.tsx
@@ -21,33 +21,32 @@ ModalMotion.defaultProps = {
   theme: defaultTheme,
 };
 
-export const ModalWindow = React.forwardRef<HTMLDivElement>(function ModalBody(
-  { children },
-  ref
-) {
-  return (
-    <ModalMotion
-      ref={ref}
-      variants={{
-        enter: {
-          y: 0,
-          opacity: 1,
-          transition: {
-            y: { type: 'spring', stiffness: 1000, damping: 15, delay: 0.1 },
-            default: { duration: 0.3, delay: 0.1 },
+export const ModalWindow = React.forwardRef<HTMLDivElement>(
+  function ModalWindow({ children }, ref) {
+    return (
+      <ModalMotion
+        ref={ref}
+        variants={{
+          enter: {
+            y: 0,
+            opacity: 1,
+            transition: {
+              y: { type: 'spring', stiffness: 1000, damping: 15, delay: 0.1 },
+              default: { duration: 0.3, delay: 0.1 },
+            },
           },
-        },
-        exit: {
-          y: 50,
-          opacity: 0,
-          transition: { duration: 0.3 },
-        },
-      }}
-      initial="exit"
-      animate="enter"
-      exit="exit"
-    >
-      {children}
-    </ModalMotion>
-  );
-});
+          exit: {
+            y: 50,
+            opacity: 0,
+            transition: { duration: 0.3 },
+          },
+        }}
+        initial="exit"
+        animate="enter"
+        exit="exit"
+      >
+        {children}
+      </ModalMotion>
+    );
+  }
+);

--- a/packages/styled-components/src/ComponentModules/Modal/ModalWindow.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/ModalWindow.tsx
@@ -8,7 +8,6 @@ const ModalMotion = styled(motion.div)`
   box-sizing: border-box;
   background-color: #fff;
   border-radius: ${(p) => p.theme.modal.borderRadius}px;
-  padding: ${(p) => p.theme.modal.padding}px;
   text-align: left;
   position: relative;
   max-width: 650px;
@@ -16,10 +15,6 @@ const ModalMotion = styled(motion.div)`
   font-family: ${(p) => p.theme.modal.fontFamily};
   font-size: ${(p) => p.theme.modal.fontSize}px;
   line-height: ${(p) => p.theme.modal.lineHeight}px;
-
-  @media screen and (min-width: 400px) {
-    padding: 20px 32px 32px;
-  }
 `;
 
 ModalMotion.defaultProps = {

--- a/packages/styled-components/src/ComponentModules/Modal/ModalWindow.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/ModalWindow.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import styled from 'styled-components';
+
+import { defaultTheme } from '../../Theme';
+
+const ModalMotion = styled(motion.div)`
+  box-sizing: border-box;
+  background-color: #fff;
+  border-radius: ${(p) => p.theme.modal.borderRadius}px;
+  padding: ${(p) => p.theme.modal.padding}px;
+  text-align: left;
+  position: relative;
+  max-width: 650px;
+  margin: 40px auto;
+  font-family: ${(p) => p.theme.modal.fontFamily};
+  font-size: ${(p) => p.theme.modal.fontSize}px;
+  line-height: ${(p) => p.theme.modal.lineHeight}px;
+
+  @media screen and (min-width: 400px) {
+    padding: 20px 32px 32px;
+  }
+`;
+
+ModalMotion.defaultProps = {
+  theme: defaultTheme,
+};
+
+export const ModalWindow = React.forwardRef<HTMLDivElement>(function ModalBody(
+  { children },
+  ref
+) {
+  return (
+    <ModalMotion
+      ref={ref}
+      variants={{
+        enter: {
+          y: 0,
+          opacity: 1,
+          transition: {
+            y: { type: 'spring', stiffness: 1000, damping: 15, delay: 0.1 },
+            default: { duration: 0.3, delay: 0.1 },
+          },
+        },
+        exit: {
+          y: 50,
+          opacity: 0,
+          transition: { duration: 0.3 },
+        },
+      }}
+      initial="exit"
+      animate="enter"
+      exit="exit"
+    >
+      {children}
+    </ModalMotion>
+  );
+});

--- a/packages/styled-components/src/ComponentModules/Modal/Title.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/Title.tsx
@@ -2,5 +2,5 @@ import styled from 'styled-components';
 
 export const Title = styled.h3`
   flex: 1;
-  margin: 0 0 20px;
+  margin: 0;
 `;

--- a/packages/styled-components/src/ComponentModules/Modal/Title.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/Title.tsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const Title = styled.h3`
+  flex: 1;
+  margin: 0 0 20px;
+`;

--- a/packages/styled-components/src/ComponentModules/Modal/Wrap.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/Wrap.tsx
@@ -18,12 +18,7 @@ export const Wrap = styled.div`
   animation-iteration-count: 2;
   zoom: 1;
   transform-style: preserve-3d;
-
-  ::before {
-    content: '';
-    display: inline-block;
-    height: 100%;
-    vertical-align: middle;
-    margin-right: -0.25em;
-  }
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 `;

--- a/packages/styled-components/src/ComponentModules/Modal/Wrap.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/Wrap.tsx
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+
+export const Wrap = styled.div`
+  box-sizing: border-box;
+  text-align: center;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  padding: 0 8px;
+  white-space: nowrap;
+  position: fixed;
+  overflow-x: hidden;
+  overflow-y: auto;
+  z-index: 1;
+  -webkit-animation-iteration-count: 2;
+  animation-iteration-count: 2;
+  zoom: 1;
+  transform-style: preserve-3d;
+
+  ::before {
+    content: '';
+    display: inline-block;
+    height: 100%;
+    vertical-align: middle;
+    margin-right: -0.25em;
+  }
+`;

--- a/packages/styled-components/src/ComponentModules/Modal/defaults.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/defaults.tsx
@@ -1,5 +1,4 @@
 import { AnimatePresence } from 'framer-motion';
-import styled from 'styled-components';
 
 import {
   BodyOverflowHidden,
@@ -9,14 +8,13 @@ import {
 import { Container } from './Container';
 import { Close } from './Close';
 import { BackDrop } from './BackDrop';
+import { Body } from './Body';
 import { Header } from './Header';
 import { ModalWindow } from './ModalWindow';
 import { Title } from './Title';
 import { Wrap } from './Wrap';
 import { ModalCallbacks } from './ModalCallbacks';
 import { ModalComponents } from './ModalComponents';
-
-const Body = styled.div``;
 
 export const defaultModalComponents: ModalComponents = {
   Wrapper: AnimatePresence,

--- a/packages/styled-components/src/ComponentModules/Modal/defaults.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/defaults.tsx
@@ -1,175 +1,32 @@
-import React from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { AnimatePresence } from 'framer-motion';
 import styled from 'styled-components';
-
-import { defaultTheme } from '../../Theme';
 
 import {
   BodyOverflowHidden,
   DelayExit,
   TransparentCurtain,
 } from '../../Components';
+import { Container } from './Container';
+import { Close } from './Close';
+import { BackDrop } from './BackDrop';
+import { Header } from './Header';
+import { ModalWindow } from './ModalWindow';
+import { Title } from './Title';
+import { Wrap } from './Wrap';
 import { ModalCallbacks } from './ModalCallbacks';
-
-const BackDropMotion = styled(motion.div)`
-  background-color: rgba(0, 0, 0, 0.8);
-  position: fixed;
-  top: 0;
-  height: 100%;
-  right: 0;
-  width: 100%;
-  z-index: 100;
-`;
-
-const BackDrop: React.FC<any> = ({ children }) => (
-  <BackDropMotion
-    variants={{
-      enter: {
-        opacity: 1,
-        transition: {
-          default: { duration: 0.15 },
-        },
-      },
-      exit: {
-        opacity: 0,
-        transition: {
-          default: { duration: 0.15 },
-        },
-      },
-    }}
-    initial="exit"
-    animate="enter"
-    exit="exit"
-  >
-    {children}
-  </BackDropMotion>
-);
-
-const Wrap = styled.div`
-  box-sizing: border-box;
-  text-align: center;
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  left: 0;
-  top: 0;
-  padding: 0 8px;
-  white-space: nowrap;
-  position: fixed;
-  overflow-x: hidden;
-  overflow-y: auto;
-  z-index: 1;
-  -webkit-animation-iteration-count: 2;
-  animation-iteration-count: 2;
-  zoom: 1;
-  transform-style: preserve-3d;
-
-  ::before {
-    content: '';
-    display: inline-block;
-    height: 100%;
-    vertical-align: middle;
-    margin-right: -0.25em;
-  }
-`;
-
-const Container = styled.div`
-  white-space: normal;
-  cursor: auto;
-  width: 100%;
-  position: relative;
-  display: inline-block;
-  vertical-align: middle;
-  margin: 0 auto;
-  text-align: left;
-`;
-
-const ModalMotion = styled(motion.div)`
-  box-sizing: border-box;
-  background-color: #fff;
-  border-radius: ${(p) => p.theme.modal.borderRadius}px;
-  padding: ${(p) => p.theme.modal.padding}px;
-  text-align: left;
-  position: relative;
-  max-width: 650px;
-  margin: 40px auto;
-  font-family: ${(p) => p.theme.modal.fontFamily};
-  font-size: ${(p) => p.theme.modal.fontSize}px;
-  line-height: ${(p) => p.theme.modal.lineHeight}px;
-
-  @media screen and (min-width: 400px) {
-    padding: 20px 32px 32px;
-  }
-`;
-
-ModalMotion.defaultProps = {
-  theme: defaultTheme,
-};
-
-const Modal = React.forwardRef<any, any>(({ children }, ref) => (
-  <ModalMotion
-    ref={ref}
-    variants={{
-      enter: {
-        y: 0,
-        opacity: 1,
-        transition: {
-          y: { type: 'spring', stiffness: 1000, damping: 15, delay: 0.1 },
-          default: { duration: 0.3, delay: 0.1 },
-        },
-      },
-      exit: {
-        y: 50,
-        opacity: 0,
-        transition: { duration: 0.3 },
-      },
-    }}
-    initial="exit"
-    animate="enter"
-    exit="exit"
-  >
-    {children}
-  </ModalMotion>
-));
-
-const Header = styled.div`
-  display: flex;
-  align-items: flex-start;
-`;
-
-const Title = styled.h3`
-  flex: 1;
-  margin: 0 0 20px;
-`;
+import { ModalComponents } from './ModalComponents';
 
 const Body = styled.div``;
 
-const Icon = styled.svg`
-  fill: none;
-  stroke: black;
-  stroke-width: 2px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  cursor: pointer;
-  width: 24px;
-`;
-
-const Close: React.FC<{ onClick: any }> = ({ onClick }) => (
-  <Icon viewBox="0 0 24 24" onClick={onClick}>
-    <line x1="18" y1="6" x2="6" y2="18"></line>
-    <line x1="6" y1="6" x2="18" y2="18"></line>
-  </Icon>
-);
-
-export const defaultModalComponents = {
+export const defaultModalComponents: ModalComponents = {
   Wrapper: AnimatePresence,
   DelayExit,
-  BodyOverflowHidden,
+  GlobalStyle: BodyOverflowHidden,
   TransparentCurtain,
   BackDrop,
   Wrap,
   Container,
-  Modal,
+  ModalWindow,
   Header,
   Title,
   Close,

--- a/packages/styled-components/src/Components/DelayExit/DelayExit.tsx
+++ b/packages/styled-components/src/Components/DelayExit/DelayExit.tsx
@@ -1,22 +1,11 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 
-// export const DelayExit: React.FC<{ children: any, isMounted: boolean, delayTime: number }> = ({ children, isMounted, delayTime = 600 }) => {
-//   const [shouldRender, setShouldRender] = useState<boolean>(isMounted);
-//   const prevIsMounted = usePrevious<boolean>(isMounted);
+export interface DelayExitProps {
+  delay?: number;
+}
 
-//   useEffect(() => {
-//     if (prevIsMounted && !isMounted) {
-//       setTimeout(() => setShouldRender(false), delayTime);
-//     } else if (!prevIsMounted && isMounted) {
-//       setShouldRender(true);
-//     }
-//   }, [prevIsMounted, isMounted, setShouldRender])
-
-//   return shouldRender ? (<>{children}</>) : null;
-// }
-
-const DelayExit: React.FC<{ delay?: number }> = ({ children, delay = 0.3 }) => {
+const DelayExit: React.FC<DelayExitProps> = ({ children, delay = 0.3 }) => {
   return (
     <motion.div
       variants={{

--- a/packages/styled-components/src/Components/DelayExit/index.ts
+++ b/packages/styled-components/src/Components/DelayExit/index.ts
@@ -1,1 +1,1 @@
-export { default } from './DelayExit';
+export { default, DelayExitProps } from './DelayExit';

--- a/packages/styled-components/src/Components/IconButton/IconButton.tsx
+++ b/packages/styled-components/src/Components/IconButton/IconButton.tsx
@@ -20,8 +20,6 @@ const IconButton = styled.button.attrs({ type: 'button' })`
   height: 48px;
   padding: 0;
   transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-
-  z-index: 1;
 `;
 
 export default IconButton;

--- a/packages/styled-components/src/Theme/base/colors.ts
+++ b/packages/styled-components/src/Theme/base/colors.ts
@@ -1,5 +1,6 @@
 export interface ColorsTheme {
   white: string;
+  black: string;
   grey100: string;
   grey200: string;
   grey250: string;
@@ -41,6 +42,7 @@ export interface ColorsTheme {
 
 const colors: ColorsTheme = {
   white: '#ffffff',
+  black: '#000000',
   grey100: '#fcfcfc',
   grey200: '#dedede',
   grey250: '#9a9a9a',

--- a/packages/styled-components/src/Theme/components/modal.ts
+++ b/packages/styled-components/src/Theme/components/modal.ts
@@ -6,6 +6,11 @@ export interface ModalTheme {
   fontSize: number;
   lineHeight: number;
   borderRadius: number;
+  header: {
+    background: string;
+    color: string;
+    closeIconColor: string;
+  };
 }
 
 export default (baseTheme: BaseTheme): ModalTheme => ({
@@ -14,4 +19,9 @@ export default (baseTheme: BaseTheme): ModalTheme => ({
   fontSize: baseTheme.typography.regular.size,
   lineHeight: baseTheme.typography.regular.lineHeight,
   borderRadius: 10,
+  header: {
+    background: baseTheme.colors.white,
+    color: 'inherit',
+    closeIconColor: baseTheme.colors.black,
+  },
 });

--- a/packages/traversal-core/package-lock.json
+++ b/packages/traversal-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-core",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/traversal-core/package.json
+++ b/packages/traversal-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-core",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Doctorlink traversal core package",
   "author": "DoctorLink Team <ben.redmond-benham@doctorlink.com>",
   "homepage": "https://github.com/DoctorLink/npm#readme",

--- a/packages/traversal-core/src/Models/index.ts
+++ b/packages/traversal-core/src/Models/index.ts
@@ -2,6 +2,7 @@ export * from './Traversal';
 export * from './Summary';
 export * from './Conclusion';
 export * from './HealthAssessment';
+export * from './Modal';
 export * from './State';
 export * from './Service';
 export * from './Utility';

--- a/packages/traversal-embed/package.json
+++ b/packages/traversal-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-embed",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Doctorlink's embeded traversal client",
   "keywords": [
     "doctorlink",
@@ -33,8 +33,8 @@
     "serve": "npm run build && serve ."
   },
   "dependencies": {
-    "@doctorlink/styled-components": "^0.7.2",
-    "@doctorlink/traversal-core": "^0.7.2",
-    "@doctorlink/traversal-redux": "^0.7.2"
+    "@doctorlink/styled-components": "^0.8.0",
+    "@doctorlink/traversal-core": "^0.8.0",
+    "@doctorlink/traversal-redux": "^0.8.0"
   }
 }

--- a/packages/traversal-redux/package-lock.json
+++ b/packages/traversal-redux/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-redux",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/traversal-redux/package.json
+++ b/packages/traversal-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-redux",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Doctorlink traversal redux package",
   "author": "DoctorLink Team <ben.redmond-benham@doctorlink.com>",
   "homepage": "https://github.com/DoctorLink/npm#readme",
@@ -31,7 +31,7 @@
     "test": "tsc --noEmit && jest test"
   },
   "dependencies": {
-    "@doctorlink/traversal-core": "^0.7.2",
+    "@doctorlink/traversal-core": "^0.8.0",
     "axios": "^0.19.2",
     "normalizr": "^3.6.0",
     "redux": "^4.0.5",


### PR DESCRIPTION
- Strongly type Modal components and split out the ones in `defaults.tsx` into their own files
- Make modal header background and colour themeable
- Move some padding around so the header can be given a coloured background
- Remove the extra 0.25em left margin on the modal
- Remove `z-index: 1` on `IconButton`. I think this might have been necessary in the old design where the i buttons were on top of the question boxes, but it isn't any more and was causing the buttons to appear in front of the bottom bar.