### PR TITLE
#1612: Prevent tall modal overlapping header

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.8.0"
+  "version": "0.8.1"
 }

--- a/packages/styled-components/package-lock.json
+++ b/packages/styled-components/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@doctorlink/styled-components",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/styled-components",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Doctorlink styled components",
   "keywords": [
     "styled-components"
@@ -34,8 +34,8 @@
     "test": "tsc --noEmit && jest test"
   },
   "dependencies": {
-    "@doctorlink/traversal-core": "^0.8.0",
-    "@doctorlink/traversal-redux": "^0.8.0",
+    "@doctorlink/traversal-core": "^0.8.1",
+    "@doctorlink/traversal-redux": "^0.8.1",
     "@testing-library/jest-dom": "^5.11.2",
     "@types/react-redux": "^7.1.9",
     "@types/react-responsive": "^8.0.2",

--- a/packages/styled-components/src/ComponentModules/Modal/ModalWindow.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/ModalWindow.tsx
@@ -11,7 +11,7 @@ const ModalMotion = styled(motion.div)`
   text-align: left;
   position: relative;
   max-width: 650px;
-  margin: 40px auto;
+  margin: ${(p) => p.theme.modal.marginX}px auto;
   font-family: ${(p) => p.theme.modal.fontFamily};
   font-size: ${(p) => p.theme.modal.fontSize}px;
   line-height: ${(p) => p.theme.modal.lineHeight}px;

--- a/packages/styled-components/src/ComponentModules/Modal/Wrap.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/Wrap.tsx
@@ -18,6 +18,7 @@ export const Wrap = styled.div`
   zoom: 1;
   transform-style: preserve-3d;
 
+  /* This keeps smaller modals centered vertically and prevents tall ones from disappearing off the top of the screen */
   ::before {
     content: '';
     display: inline-block;

--- a/packages/styled-components/src/ComponentModules/Modal/Wrap.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/Wrap.tsx
@@ -3,14 +3,13 @@ import styled from 'styled-components';
 export const Wrap = styled.div`
   box-sizing: border-box;
   text-align: center;
-  position: absolute;
+  position: fixed;
   width: 100%;
   height: 100%;
   left: 0;
   top: 0;
   padding: 0 8px;
   white-space: nowrap;
-  position: fixed;
   overflow-x: hidden;
   overflow-y: auto;
   z-index: 1;
@@ -18,7 +17,11 @@ export const Wrap = styled.div`
   animation-iteration-count: 2;
   zoom: 1;
   transform-style: preserve-3d;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
+
+  ::before {
+    content: '';
+    display: inline-block;
+    height: 100%;
+    vertical-align: middle;
+  }
 `;

--- a/packages/styled-components/src/Theme/components/modal.ts
+++ b/packages/styled-components/src/Theme/components/modal.ts
@@ -6,6 +6,7 @@ export interface ModalTheme {
   fontSize: number;
   lineHeight: number;
   borderRadius: number;
+  marginX: number;
   header: {
     background: string;
     color: string;
@@ -19,6 +20,7 @@ export default (baseTheme: BaseTheme): ModalTheme => ({
   fontSize: baseTheme.typography.regular.size,
   lineHeight: baseTheme.typography.regular.lineHeight,
   borderRadius: 10,
+  marginX: 40,
   header: {
     background: baseTheme.colors.white,
     color: 'inherit',

--- a/packages/traversal-core/package-lock.json
+++ b/packages/traversal-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/traversal-core/package.json
+++ b/packages/traversal-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Doctorlink traversal core package",
   "author": "DoctorLink Team <ben.redmond-benham@doctorlink.com>",
   "homepage": "https://github.com/DoctorLink/npm#readme",

--- a/packages/traversal-embed/package.json
+++ b/packages/traversal-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-embed",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Doctorlink's embeded traversal client",
   "keywords": [
     "doctorlink",
@@ -33,8 +33,8 @@
     "serve": "npm run build && serve ."
   },
   "dependencies": {
-    "@doctorlink/styled-components": "^0.8.0",
-    "@doctorlink/traversal-core": "^0.8.0",
-    "@doctorlink/traversal-redux": "^0.8.0"
+    "@doctorlink/styled-components": "^0.8.1",
+    "@doctorlink/traversal-core": "^0.8.1",
+    "@doctorlink/traversal-redux": "^0.8.1"
   }
 }

--- a/packages/traversal-redux/package-lock.json
+++ b/packages/traversal-redux/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-redux",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/traversal-redux/package.json
+++ b/packages/traversal-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-redux",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Doctorlink traversal redux package",
   "author": "DoctorLink Team <ben.redmond-benham@doctorlink.com>",
   "homepage": "https://github.com/DoctorLink/npm#readme",
@@ -31,7 +31,7 @@
     "test": "tsc --noEmit && jest test"
   },
   "dependencies": {
-    "@doctorlink/traversal-core": "^0.8.0",
+    "@doctorlink/traversal-core": "^0.8.1",
     "axios": "^0.19.2",
     "normalizr": "^3.6.0",
     "redux": "^4.0.5",


### PR DESCRIPTION
Reinstate the pseudo-element that I removed in error (https://github.com/DoctorLink/npm/pull/32/commits/3ff5cc9ed2cf1704cbba958f6cc52466e29876ba) - turns out it was simultaneously keeping the modal centered and stopping it disappearing off the top of the page.
Make the top/bottom margin themeable so we can keep the modal below the header in the demo app.