### PR TITLE
Avoid large gap when editing previously answered chat question

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.8.2"
+  "version": "0.8.3"
 }

--- a/packages/styled-components/package-lock.json
+++ b/packages/styled-components/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@doctorlink/styled-components",
-	"version": "0.8.2",
+	"version": "0.8.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/styled-components",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Doctorlink styled components",
   "keywords": [
     "styled-components"
@@ -34,8 +34,8 @@
     "test": "tsc --noEmit && jest test"
   },
   "dependencies": {
-    "@doctorlink/traversal-core": "^0.8.2",
-    "@doctorlink/traversal-redux": "^0.8.2",
+    "@doctorlink/traversal-core": "^0.8.3",
+    "@doctorlink/traversal-redux": "^0.8.3",
     "@testing-library/jest-dom": "^5.11.2",
     "@types/react-redux": "^7.1.9",
     "@types/react-responsive": "^8.0.2",

--- a/packages/styled-components/src/ComponentModules/Chat/Chat.tsx
+++ b/packages/styled-components/src/ComponentModules/Chat/Chat.tsx
@@ -1,6 +1,6 @@
-import React, { RefObject } from 'react';
+import React, { useRef } from 'react';
 import { defaultChatActions, defaultChatComponents } from './defaults';
-import { useChatScroll } from '../../Hooks/useChatScroll';
+import { useChatScroll, useChatMinHeight } from '../../Hooks';
 import { ChatTraversalState } from '@doctorlink/traversal-core';
 import { ChatTraversalCallbacks } from './ChatCallbacks';
 import { ChatComponents } from './ChatComponents';
@@ -9,21 +9,23 @@ import { ChatStep } from './ChatStep';
 interface ChatTraversalProps {
   traversal: ChatTraversalState;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  containerRef?: RefObject<any>;
   actions?: ChatTraversalCallbacks;
   components?: Partial<ChatComponents>;
 }
 
 export const ChatTraversal: React.FC<ChatTraversalProps> = ({
   traversal,
-  containerRef,
   actions = defaultChatActions,
   components = defaultChatComponents,
 }) => {
   const comps = { ...defaultChatComponents, ...components };
   const { Container, Step, Loader } = comps;
   const { questionIds, loading } = traversal;
-  const minHeight = useChatScroll(loading, questionIds.length, containerRef);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const minHeight = useChatMinHeight(loading, containerRef);
+  useChatScroll(questionIds.length, containerRef);
+
   return (
     <Container id="Traversal" minHeight={minHeight} ref={containerRef}>
       {questionIds.map((questionId) => (

--- a/packages/styled-components/src/Containers/ChatTraversal/index.tsx
+++ b/packages/styled-components/src/Containers/ChatTraversal/index.tsx
@@ -1,10 +1,9 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import { ChatTraversalRootState } from '@doctorlink/traversal-core';
 import { ChatTraversal, useChatActions } from '../../ComponentModules';
 
 export const ChatTraversalConnected: React.FC = () => {
-  const ref = useRef();
   const traversal = useSelector(
     (state: ChatTraversalRootState) => state.chatTraversal
   );
@@ -14,7 +13,5 @@ export const ChatTraversalConnected: React.FC = () => {
     return null;
   }
 
-  return (
-    <ChatTraversal traversal={traversal} containerRef={ref} actions={actions} />
-  );
+  return <ChatTraversal traversal={traversal} actions={actions} />;
 };

--- a/packages/styled-components/src/Containers/ChatTraversalAndConclusions/index.tsx
+++ b/packages/styled-components/src/Containers/ChatTraversalAndConclusions/index.tsx
@@ -1,11 +1,10 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import { ConclusionReportConnected as Conclusions } from '../ConclusionReport';
 import { ChatTraversal, useChatActions } from '../../ComponentModules';
 import { ChatTraversalRootState } from '@doctorlink/traversal-core';
 
 export const ChatTraversalAndConclusionsConnected: React.FC = () => {
-  const ref = useRef();
   const traversal = useSelector(
     (state: ChatTraversalRootState) => state.chatTraversal
   );
@@ -28,11 +27,7 @@ export const ChatTraversalAndConclusionsConnected: React.FC = () => {
 
   return (
     <>
-      <ChatTraversal
-        traversal={traversal}
-        containerRef={ref}
-        actions={actions}
-      />
+      <ChatTraversal traversal={traversal} actions={actions} />
     </>
   );
 };

--- a/packages/styled-components/src/Hooks/index.ts
+++ b/packages/styled-components/src/Hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './useChatMinHeight';
 export * from './useChatScroll';
 export * from './useHealthAge';
 export * from './useHRARoutes';

--- a/packages/styled-components/src/Hooks/useChatMinHeight.ts
+++ b/packages/styled-components/src/Hooks/useChatMinHeight.ts
@@ -1,0 +1,20 @@
+import { RefObject, useState, useEffect } from 'react';
+
+export function useChatMinHeight<E extends HTMLElement>(
+  loading: boolean,
+  ref: RefObject<E>
+): number {
+  const [latestHeight, setLatestHeight] = useState(0);
+  const clientHeight = ref.current?.clientHeight;
+
+  // Track the most recent height when not loading
+  useEffect(() => {
+    if (!loading) {
+      setLatestHeight(clientHeight ?? 0);
+    }
+  }, [loading, clientHeight]);
+
+  // Maintain that height while the next question is loading, to keep the questions in the same place while the answer options are removed from the DOM.
+  // Once loaded, set the min height back to 0 to avoid dead space at the bottom (especially if we have jumped back to an earlier question).
+  return loading ? latestHeight : 0;
+}

--- a/packages/styled-components/src/Hooks/useChatScroll.ts
+++ b/packages/styled-components/src/Hooks/useChatScroll.ts
@@ -1,29 +1,18 @@
-import { MutableRefObject, useState, useEffect } from 'react';
+import { RefObject, useEffect } from 'react';
 import usePrevious from './usePrevious';
 
-export const useChatScroll = function (
-  loading: boolean,
+export const useChatScroll = function <E extends HTMLElement>(
   totalQuestions: number,
-  ref?: MutableRefObject<any>
-): number {
-  const [height, setHeight] = useState(0);
-  const [minHeight, setMinHeight] = useState(0);
-  const prevHeight = usePrevious(height);
+  ref: RefObject<E>
+): void {
   const prevTotalQuestions = usePrevious(totalQuestions);
+
   useEffect(() => {
-    if (!ref) return;
-    if (ref.current && ref.current.clientHeight) {
-      setHeight(ref.current.clientHeight);
-      if (loading) setMinHeight(prevHeight ?? 0);
-    }
     if (prevTotalQuestions !== totalQuestions) {
-      const children = ref && ref.current && ref.current.children;
-      if (children) {
-        const lastChild = children.length > 0 && children[children.length - 1];
-        if (lastChild) lastChild.scrollIntoView({ behavior: 'smooth' });
+      const lastChild = ref.current?.lastElementChild;
+      if (lastChild) {
+        lastChild.scrollIntoView({ behavior: 'smooth' });
       }
     }
-  }, [loading, ref, totalQuestions, prevTotalQuestions, prevHeight]);
-
-  return minHeight;
+  }, [ref, totalQuestions, prevTotalQuestions]);
 };

--- a/packages/styled-components/src/Hooks/usePrevious.ts
+++ b/packages/styled-components/src/Hooks/usePrevious.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-const usePrevious = function <T>(value: T) {
+const usePrevious = function <T>(value: T): T | undefined {
   const ref = useRef<T>();
   useEffect(() => {
     ref.current = value;

--- a/packages/traversal-core/package-lock.json
+++ b/packages/traversal-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-core",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/traversal-core/package.json
+++ b/packages/traversal-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-core",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Doctorlink traversal core package",
   "author": "DoctorLink Team <ben.redmond-benham@doctorlink.com>",
   "homepage": "https://github.com/DoctorLink/npm#readme",

--- a/packages/traversal-embed/package.json
+++ b/packages/traversal-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-embed",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Doctorlink's embeded traversal client",
   "keywords": [
     "doctorlink",
@@ -33,8 +33,8 @@
     "serve": "npm run build && serve ."
   },
   "dependencies": {
-    "@doctorlink/styled-components": "^0.8.2",
-    "@doctorlink/traversal-core": "^0.8.2",
-    "@doctorlink/traversal-redux": "^0.8.2"
+    "@doctorlink/styled-components": "^0.8.3",
+    "@doctorlink/traversal-core": "^0.8.3",
+    "@doctorlink/traversal-redux": "^0.8.3"
   }
 }

--- a/packages/traversal-redux/package-lock.json
+++ b/packages/traversal-redux/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-redux",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/traversal-redux/package.json
+++ b/packages/traversal-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-redux",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Doctorlink traversal redux package",
   "author": "DoctorLink Team <ben.redmond-benham@doctorlink.com>",
   "homepage": "https://github.com/DoctorLink/npm#readme",
@@ -31,7 +31,7 @@
     "test": "tsc --noEmit && jest test"
   },
   "dependencies": {
-    "@doctorlink/traversal-core": "^0.8.2",
+    "@doctorlink/traversal-core": "^0.8.3",
     "axios": "^0.19.2",
     "normalizr": "^3.6.0",
     "redux": "^4.0.5",


### PR DESCRIPTION
https://dev.azure.com/doctorlink-engineering/ENG/_boards/board/t/Beaconsfield/Stories/?workitem=1593

Previously we were setting the `min-height` of the chat container to its previous height, which had the effect that it could never grow smaller, even if lots of questions were removed from the traversal (because of jumping back to an earlier question). This PR sets the min-height back to 0 once each question has finished loading.

Also: refactor `useChatScroll` into two separate hooks with single responsibilities.