### PR TITLE
#1337: disposition report

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.8.3"
+  "version": "0.8.4"
 }

--- a/packages/styled-components/package-lock.json
+++ b/packages/styled-components/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@doctorlink/styled-components",
-	"version": "0.8.3",
+	"version": "0.8.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/styled-components",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Doctorlink styled components",
   "keywords": [
     "styled-components"
@@ -34,8 +34,8 @@
     "test": "tsc --noEmit && jest test"
   },
   "dependencies": {
-    "@doctorlink/traversal-core": "^0.8.3",
-    "@doctorlink/traversal-redux": "^0.8.3",
+    "@doctorlink/traversal-core": "^0.8.4",
+    "@doctorlink/traversal-redux": "^0.8.4",
     "@testing-library/jest-dom": "^5.11.2",
     "@types/react-redux": "^7.1.9",
     "@types/react-responsive": "^8.0.2",

--- a/packages/styled-components/src/ComponentModules/Modal/Modal.tsx
+++ b/packages/styled-components/src/ComponentModules/Modal/Modal.tsx
@@ -8,7 +8,7 @@ import { ModalComponents } from './ModalComponents';
 export const Modal: React.FC<{
   modal: ModalModel | null;
   actions?: ModalCallbacks;
-  components?: ModalComponents;
+  components?: Partial<ModalComponents>;
 }> = ({
   modal,
   children,

--- a/packages/styled-components/src/ComponentModules/SymptomReport/BulletsPanel.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/BulletsPanel.tsx
@@ -1,14 +1,28 @@
 import { ConclusionBullet } from '@doctorlink/traversal-core';
 import React from 'react';
+import { AccordionBody, AccordionHeader } from '../../Components';
+import { useToggle } from '../../Hooks';
 import { SymptomReportComponents } from './SymptomReportComponents';
 
-export const BulletsPanel: React.FC<{
+interface BulletsPanelProps {
   bullets: ConclusionBullet[];
   title: string;
   headerColor: string;
   firstItemBold?: boolean;
+  collapse?: boolean;
   components: SymptomReportComponents;
-}> = ({ bullets, title, headerColor, firstItemBold, components }) => {
+}
+
+export const BulletsPanel: React.FC<BulletsPanelProps> = ({
+  bullets,
+  title,
+  headerColor,
+  firstItemBold,
+  collapse,
+  components,
+}) => {
+  const [open, toggleOpen] = useToggle(!collapse);
+
   if (!bullets?.length) {
     return null;
   }
@@ -18,15 +32,19 @@ export const BulletsPanel: React.FC<{
   return (
     <Panel>
       <Header color={headerColor}>
-        <Title>{title}</Title>
+        <AccordionHeader open={open} toggleOpen={toggleOpen}>
+          <Title>{title}</Title>
+        </AccordionHeader>
       </Header>
-      {bullets.map((bullet, i) => (
-        <Conclusion key={bullet.bulletUniqueId}>
-          <BodyText bold={firstItemBold && i === 0}>
-            {bullet.displayText}
-          </BodyText>
-        </Conclusion>
-      ))}
+      <AccordionBody open={open}>
+        {bullets.map((bullet, i) => (
+          <Conclusion key={bullet.bulletUniqueId}>
+            <BodyText bold={firstItemBold && i === 0}>
+              {bullet.displayText}
+            </BodyText>
+          </Conclusion>
+        ))}
+      </AccordionBody>
     </Panel>
   );
 };

--- a/packages/styled-components/src/ComponentModules/SymptomReport/BulletsPanel.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/BulletsPanel.tsx
@@ -1,7 +1,6 @@
 import { ConclusionBullet } from '@doctorlink/traversal-core';
 import React from 'react';
-import { AccordionBody, AccordionHeader } from '../../Components';
-import { useToggle } from '../../Hooks';
+import { CollapsiblePanel } from './CollapsiblePanel';
 import { SymptomReportComponents } from './SymptomReportComponents';
 
 interface BulletsPanelProps {
@@ -21,30 +20,34 @@ export const BulletsPanel: React.FC<BulletsPanelProps> = ({
   collapse,
   components,
 }) => {
-  const [open, toggleOpen] = useToggle(!collapse);
-
   if (!bullets?.length) {
     return null;
   }
 
-  const { Panel, Header, Title, Conclusion, BodyText } = components;
+  const { Conclusion, BodyText } = components;
 
   return (
-    <Panel>
-      <Header color={headerColor}>
-        <AccordionHeader open={open} toggleOpen={toggleOpen}>
-          <Title>{title}</Title>
-        </AccordionHeader>
-      </Header>
-      <AccordionBody open={open}>
-        {bullets.map((bullet, i) => (
+    <CollapsiblePanel
+      title={title}
+      headerColor={headerColor}
+      collapse={collapse}
+      components={components}
+    >
+      {bullets.map((bullet, i) => {
+        const bold = firstItemBold && i === 0;
+        const bulletStyle = bold
+          ? undefined
+          : bullet.category2.startsWith('Alert: Danger Signs')
+          ? 'warning'
+          : 'default';
+        return (
           <Conclusion key={bullet.bulletUniqueId}>
-            <BodyText bold={firstItemBold && i === 0}>
+            <BodyText bullet={bulletStyle} bold={bold}>
               {bullet.displayText}
             </BodyText>
           </Conclusion>
-        ))}
-      </AccordionBody>
-    </Panel>
+        );
+      })}
+    </CollapsiblePanel>
   );
 };

--- a/packages/styled-components/src/ComponentModules/SymptomReport/BulletsPanel.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/BulletsPanel.tsx
@@ -1,0 +1,32 @@
+import { ConclusionBullet } from '@doctorlink/traversal-core';
+import React from 'react';
+import { SymptomReportComponents } from './SymptomReportComponents';
+
+export const BulletsPanel: React.FC<{
+  bullets: ConclusionBullet[];
+  title: string;
+  headerColor: string;
+  firstItemBold?: boolean;
+  components: SymptomReportComponents;
+}> = ({ bullets, title, headerColor, firstItemBold, components }) => {
+  if (!bullets?.length) {
+    return null;
+  }
+
+  const { Panel, Header, Title, Conclusion, BodyText } = components;
+
+  return (
+    <Panel>
+      <Header color={headerColor}>
+        <Title>{title}</Title>
+      </Header>
+      {bullets.map((bullet, i) => (
+        <Conclusion key={bullet.bulletUniqueId}>
+          <BodyText bold={firstItemBold && i === 0}>
+            {bullet.displayText}
+          </BodyText>
+        </Conclusion>
+      ))}
+    </Panel>
+  );
+};

--- a/packages/styled-components/src/ComponentModules/SymptomReport/CollapsiblePanel.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/CollapsiblePanel.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useTheme } from 'styled-components';
+import { AccordionBody, AccordionHeader } from '../../Components';
+import { useToggle } from '../../Hooks';
+import { SymptomReportComponents } from './SymptomReportComponents';
+
+interface CollapsiblePanelProps {
+  title: string;
+  headerColor: string;
+  collapse?: boolean;
+  components: SymptomReportComponents;
+}
+
+export const CollapsiblePanel: React.FC<CollapsiblePanelProps> = ({
+  title,
+  headerColor,
+  collapse,
+  components,
+  children,
+}) => {
+  const [open, toggleOpen] = useToggle(!collapse);
+  const theme = useTheme();
+
+  const { Panel, Header, Title } = components;
+
+  return (
+    <Panel>
+      <Header color={headerColor}>
+        <AccordionHeader open={open} toggleOpen={toggleOpen}>
+          <Title color={theme.symptomReport.panelHeaders.textColor}>
+            {title}
+          </Title>
+        </AccordionHeader>
+      </Header>
+      <AccordionBody open={open}>{children}</AccordionBody>
+    </Panel>
+  );
+};

--- a/packages/styled-components/src/ComponentModules/SymptomReport/ConclusionsPanel.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/ConclusionsPanel.tsx
@@ -1,5 +1,7 @@
 import { Conclusion } from '@doctorlink/traversal-core';
 import React from 'react';
+import { AccordionBody, AccordionHeader } from '../../Components';
+import { useToggle } from '../../Hooks';
 import { SymptomReportCallbacks } from './SymptomReportCallbacks';
 import { SymptomReportComponents } from './SymptomReportComponents';
 
@@ -8,6 +10,7 @@ interface ConclusionPanelProps {
   conclusions: Conclusion[];
   headerColor: string;
   showTruncated?: boolean;
+  collapse?: boolean;
   actions: SymptomReportCallbacks;
   components: SymptomReportComponents;
 }
@@ -17,9 +20,12 @@ export const ConclusionsPanel: React.FC<ConclusionPanelProps> = ({
   title,
   headerColor,
   showTruncated,
+  collapse,
   actions,
   components,
 }) => {
+  const [open, toggleOpen] = useToggle(!collapse);
+
   if (!conclusions?.length) {
     return null;
   }
@@ -37,18 +43,22 @@ export const ConclusionsPanel: React.FC<ConclusionPanelProps> = ({
   return (
     <Panel>
       <Header color={headerColor}>
-        <Title>{title}</Title>
+        <AccordionHeader open={open} toggleOpen={toggleOpen}>
+          <Title>{title}</Title>
+        </AccordionHeader>
       </Header>
-      {conclusions.map((conclusion) => (
-        <Conclusion key={conclusion.assetId}>
-          <ConclusionTitle>{conclusion.displayText}</ConclusionTitle>
-          <Info
-            onClick={actions.showExplanation}
-            explanation={conclusion.explanation}
-          />
-          {showTruncated && <BodyText>{conclusion.truncated}</BodyText>}
-        </Conclusion>
-      ))}
+      <AccordionBody open={open}>
+        {conclusions.map((conclusion) => (
+          <Conclusion key={conclusion.assetId}>
+            <ConclusionTitle>{conclusion.displayText}</ConclusionTitle>
+            <Info
+              onClick={actions.showExplanation}
+              explanation={conclusion.explanation}
+            />
+            {showTruncated && <BodyText>{conclusion.truncated}</BodyText>}
+          </Conclusion>
+        ))}
+      </AccordionBody>
     </Panel>
   );
 };

--- a/packages/styled-components/src/ComponentModules/SymptomReport/ConclusionsPanel.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/ConclusionsPanel.tsx
@@ -1,7 +1,6 @@
 import { Conclusion } from '@doctorlink/traversal-core';
 import React from 'react';
-import { AccordionBody, AccordionHeader } from '../../Components';
-import { useToggle } from '../../Hooks';
+import { CollapsiblePanel } from './CollapsiblePanel';
 import { SymptomReportCallbacks } from './SymptomReportCallbacks';
 import { SymptomReportComponents } from './SymptomReportComponents';
 
@@ -22,39 +21,29 @@ export const ConclusionsPanel: React.FC<ConclusionPanelProps> = ({
   actions,
   components,
 }) => {
-  const [open, toggleOpen] = useToggle(!collapse);
-
   if (!conclusions?.length) {
     return null;
   }
 
-  const {
-    Panel,
-    Header,
-    Title,
-    Conclusion,
-    ConclusionTitle,
-    Info,
-  } = components;
-
+  const { Conclusion, BodyText, Info } = components;
   return (
-    <Panel>
-      <Header color={headerColor}>
-        <AccordionHeader open={open} toggleOpen={toggleOpen}>
-          <Title>{title}</Title>
-        </AccordionHeader>
-      </Header>
-      <AccordionBody open={open}>
-        {conclusions.map((conclusion) => (
-          <Conclusion key={conclusion.assetId}>
-            <ConclusionTitle>{conclusion.displayText}</ConclusionTitle>
+    <CollapsiblePanel
+      title={title}
+      headerColor={headerColor}
+      collapse={collapse}
+      components={components}
+    >
+      {conclusions.map((conclusion) => (
+        <Conclusion key={conclusion.assetId}>
+          <BodyText bullet="default">
+            {conclusion.displayText}
             <Info
               onClick={actions.showExplanation}
               explanation={conclusion.explanation}
             />
-          </Conclusion>
-        ))}
-      </AccordionBody>
-    </Panel>
+          </BodyText>
+        </Conclusion>
+      ))}
+    </CollapsiblePanel>
   );
 };

--- a/packages/styled-components/src/ComponentModules/SymptomReport/ConclusionsPanel.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/ConclusionsPanel.tsx
@@ -1,0 +1,54 @@
+import { Conclusion } from '@doctorlink/traversal-core';
+import React from 'react';
+import { SymptomReportCallbacks } from './SymptomReportCallbacks';
+import { SymptomReportComponents } from './SymptomReportComponents';
+
+interface ConclusionPanelProps {
+  title: string;
+  conclusions: Conclusion[];
+  headerColor: string;
+  showTruncated?: boolean;
+  actions: SymptomReportCallbacks;
+  components: SymptomReportComponents;
+}
+
+export const ConclusionsPanel: React.FC<ConclusionPanelProps> = ({
+  conclusions,
+  title,
+  headerColor,
+  showTruncated,
+  actions,
+  components,
+}) => {
+  if (!conclusions?.length) {
+    return null;
+  }
+
+  const {
+    Panel,
+    Header,
+    Title,
+    Conclusion,
+    ConclusionTitle,
+    Info,
+    BodyText,
+  } = components;
+
+  return (
+    <Panel>
+      <Header color={headerColor}>
+        <Title>{title}</Title>
+      </Header>
+      {conclusions.map((conclusion) => (
+        <Conclusion key={conclusion.assetId}>
+          <ConclusionTitle>{conclusion.displayText}</ConclusionTitle>
+          <Info
+            onClick={actions.showExplanation}
+            explanation={conclusion.explanation}
+          />
+          {showTruncated && <BodyText>{conclusion.truncated}</BodyText>}
+        </Conclusion>
+      ))}
+    </Panel>
+  );
+};

--- a/packages/styled-components/src/ComponentModules/SymptomReport/ConclusionsPanel.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/ConclusionsPanel.tsx
@@ -9,7 +9,6 @@ interface ConclusionPanelProps {
   title: string;
   conclusions: Conclusion[];
   headerColor: string;
-  showTruncated?: boolean;
   collapse?: boolean;
   actions: SymptomReportCallbacks;
   components: SymptomReportComponents;
@@ -19,7 +18,6 @@ export const ConclusionsPanel: React.FC<ConclusionPanelProps> = ({
   conclusions,
   title,
   headerColor,
-  showTruncated,
   collapse,
   actions,
   components,
@@ -37,7 +35,6 @@ export const ConclusionsPanel: React.FC<ConclusionPanelProps> = ({
     Conclusion,
     ConclusionTitle,
     Info,
-    BodyText,
   } = components;
 
   return (
@@ -55,7 +52,6 @@ export const ConclusionsPanel: React.FC<ConclusionPanelProps> = ({
               onClick={actions.showExplanation}
               explanation={conclusion.explanation}
             />
-            {showTruncated && <BodyText>{conclusion.truncated}</BodyText>}
           </Conclusion>
         ))}
       </AccordionBody>

--- a/packages/styled-components/src/ComponentModules/SymptomReport/Icon.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/Icon.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { PanelSVG } from '../../Components';
+
+export interface IconProps {
+  state: number;
+}
+
+export const Icon: React.FC<IconProps> = ({ state }) => {
+  if (state === 1)
+    return (
+      <PanelSVG width="24" height="24" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="10"></circle>
+        <line x1="12" y1="8" x2="12" y2="12"></line>
+        <line x1="12" y1="16" x2="12" y2="16"></line>
+      </PanelSVG>
+    );
+
+  if (state === 2)
+    return (
+      <PanelSVG width="24" height="24" viewBox="0 0 24 24">
+        <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+        <line x1="12" y1="9" x2="12" y2="13"></line>
+        <line x1="12" y1="17" x2="12" y2="17"></line>
+      </PanelSVG>
+    );
+
+  return (
+    <PanelSVG width="24" height="24" viewBox="0 0 24 24">
+      <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
+      <polyline points="22 4 12 14.01 9 11.01"></polyline>
+    </PanelSVG>
+  );
+};

--- a/packages/styled-components/src/ComponentModules/SymptomReport/Icon.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/Icon.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import { PanelSVG } from '../../Components';
+import { useMessageColor } from './useMessageColor';
 
 export interface IconProps {
   state: number;
 }
 
 export const Icon: React.FC<IconProps> = ({ state }) => {
+  const color = useMessageColor(state);
   if (state === 1)
     return (
-      <PanelSVG width="24" height="24" viewBox="0 0 24 24">
+      <PanelSVG width="24" height="24" viewBox="0 0 24 24" stroke={color}>
         <circle cx="12" cy="12" r="10"></circle>
         <line x1="12" y1="8" x2="12" y2="12"></line>
         <line x1="12" y1="16" x2="12" y2="16"></line>
@@ -17,7 +19,7 @@ export const Icon: React.FC<IconProps> = ({ state }) => {
 
   if (state === 2)
     return (
-      <PanelSVG width="24" height="24" viewBox="0 0 24 24">
+      <PanelSVG width="24" height="24" viewBox="0 0 24 24" stroke={color}>
         <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
         <line x1="12" y1="9" x2="12" y2="13"></line>
         <line x1="12" y1="17" x2="12" y2="17"></line>
@@ -25,7 +27,7 @@ export const Icon: React.FC<IconProps> = ({ state }) => {
     );
 
   return (
-    <PanelSVG width="24" height="24" viewBox="0 0 24 24">
+    <PanelSVG width="24" height="24" viewBox="0 0 24 24" stroke={color}>
       <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
       <polyline points="22 4 12 14.01 9 11.01"></polyline>
     </PanelSVG>

--- a/packages/styled-components/src/ComponentModules/SymptomReport/MessagePanel.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/MessagePanel.tsx
@@ -1,0 +1,39 @@
+import { SymptomReportModel } from '@doctorlink/traversal-core';
+import React from 'react';
+import colors from '../../Theme/base/colors';
+import { SymptomReportComponents } from './SymptomReportComponents';
+
+const headerColor = (messageLevel: number) => {
+  switch (messageLevel) {
+    case 3:
+      return colors.normal;
+    case 2:
+      return colors.moderate;
+    default:
+      return colors.danger;
+  }
+};
+
+export const MessagePanel: React.FC<{
+  symptomReport: SymptomReportModel;
+  components: SymptomReportComponents;
+}> = ({ symptomReport, components }) => {
+  const { Panel, Header, Icon, Title, Content, BodyText } = components;
+  const { messageLevel, messageTitle, messageDescription } = symptomReport;
+
+  return (
+    <Panel id="Traversal">
+      <Header color={headerColor(messageLevel)}>
+        <Icon state={messageLevel} />
+        <Title>{messageTitle}</Title>
+      </Header>
+      <Content>
+        <BodyText
+          dangerouslySetInnerHTML={{
+            __html: messageDescription,
+          }}
+        />
+      </Content>
+    </Panel>
+  );
+};

--- a/packages/styled-components/src/ComponentModules/SymptomReport/MessagePanel.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/MessagePanel.tsx
@@ -12,9 +12,8 @@ export const MessagePanel: React.FC<{
   return (
     <Message level={messageLevel}>
       <Content>
-        <Title>{messageTitle}</Title>
+        <Title color="inherit">{messageTitle}</Title>
         <BodyText
-          contrastText
           dangerouslySetInnerHTML={{
             __html: messageDescription,
           }}

--- a/packages/styled-components/src/ComponentModules/SymptomReport/MessagePanel.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/MessagePanel.tsx
@@ -1,39 +1,25 @@
 import { SymptomReportModel } from '@doctorlink/traversal-core';
 import React from 'react';
-import colors from '../../Theme/base/colors';
 import { SymptomReportComponents } from './SymptomReportComponents';
-
-const headerColor = (messageLevel: number) => {
-  switch (messageLevel) {
-    case 3:
-      return colors.normal;
-    case 2:
-      return colors.moderate;
-    default:
-      return colors.danger;
-  }
-};
 
 export const MessagePanel: React.FC<{
   symptomReport: SymptomReportModel;
   components: SymptomReportComponents;
 }> = ({ symptomReport, components }) => {
-  const { Panel, Header, Icon, Title, Content, BodyText } = components;
+  const { Message, Title, Content, BodyText } = components;
   const { messageLevel, messageTitle, messageDescription } = symptomReport;
 
   return (
-    <Panel id="Traversal">
-      <Header color={headerColor(messageLevel)}>
-        <Icon state={messageLevel} />
-        <Title>{messageTitle}</Title>
-      </Header>
+    <Message level={messageLevel}>
       <Content>
+        <Title>{messageTitle}</Title>
         <BodyText
+          contrastText
           dangerouslySetInnerHTML={{
             __html: messageDescription,
           }}
         />
       </Content>
-    </Panel>
+    </Message>
   );
 };

--- a/packages/styled-components/src/ComponentModules/SymptomReport/MessagePanel.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/MessagePanel.tsx
@@ -1,18 +1,22 @@
 import { SymptomReportModel } from '@doctorlink/traversal-core';
 import React from 'react';
 import { SymptomReportComponents } from './SymptomReportComponents';
+import { useMessageColor } from './useMessageColor';
 
 export const MessagePanel: React.FC<{
   symptomReport: SymptomReportModel;
   components: SymptomReportComponents;
 }> = ({ symptomReport, components }) => {
-  const { Message, Title, Content, BodyText } = components;
+  const { Message, MessageTitle, Content, BodyText, Icon } = components;
   const { messageLevel, messageTitle, messageDescription } = symptomReport;
+  const color = useMessageColor(messageLevel);
 
   return (
-    <Message level={messageLevel}>
+    <Message color={color}>
       <Content>
-        <Title color="inherit">{messageTitle}</Title>
+        <MessageTitle>
+          <Icon state={messageLevel} /> {messageTitle}
+        </MessageTitle>
         <BodyText
           dangerouslySetInnerHTML={{
             __html: messageDescription,

--- a/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReport.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReport.tsx
@@ -1,10 +1,13 @@
 import { SymptomReportModel } from '@doctorlink/traversal-core';
 import React from 'react';
 import colors from '../../Theme/base/colors';
+import { BulletsPanel } from './BulletsPanel';
+import { ConclusionsPanel } from './ConclusionsPanel';
 import {
   defaultSymptomReportActions,
   defaultSymptomReportComponents,
 } from './defaults';
+import { MessagePanel } from './MessagePanel';
 import { SymptomReportCallbacks } from './SymptomReportCallbacks';
 import { SymptomReportComponents } from './SymptomReportComponents';
 
@@ -19,145 +22,73 @@ export const SymptomReport: React.FC<{
 }) => {
   const comps = { ...defaultSymptomReportComponents, ...components };
 
-  const level = () => {
-    switch (symptomReport.messageLevel) {
-      case 3:
-        return colors.normal;
-      case 2:
-        return colors.moderate;
-      default:
-        return colors.danger;
-    }
-  };
+  const {
+    dangerBullets,
+    dangerBulletTitle,
+    contactBullets,
+    contactBulletTitle,
+    reasonConclusions,
+    reasonConclusionTitle,
+    otherConclusions,
+    otherConclusionTitle,
+    informationConclusions,
+    informationConclusionTitle,
+    reasonBullets,
+    reasonBulletTitle,
+  } = symptomReport;
 
   return (
     <>
       <comps.Blocks key="panel" staggerChildren={0.2} style={{ margin: 0 }}>
-        <comps.Panel key="header" id="Traversal">
-          <comps.Header color={level()}>
-            <comps.Icon state={symptomReport.messageLevel} />
-            <comps.Title>{symptomReport.messageTitle}</comps.Title>
-          </comps.Header>
-          <comps.Content>
-            <comps.BodyText
-              dangerouslySetInnerHTML={{
-                __html: symptomReport.messageDescription,
-              }}
-            />
-          </comps.Content>
-        </comps.Panel>
+        <MessagePanel symptomReport={symptomReport} components={components} />
       </comps.Blocks>
       <comps.Blocks key="bullets" staggerChildren={0.2}>
         <comps.Container float={'right'}>
-          {symptomReport.dangerBullets &&
-            symptomReport.dangerBullets.length > 0 && (
-              <comps.Panel>
-                <comps.Header color={colors.danger}>
-                  <comps.Title>{symptomReport.dangerBulletTitle}</comps.Title>
-                </comps.Header>
-                {symptomReport.dangerBullets.map((bullet) => (
-                  <comps.Conclusion key={bullet.bulletUniqueId}>
-                    <comps.BodyText>{bullet.displayText}</comps.BodyText>
-                  </comps.Conclusion>
-                ))}
-              </comps.Panel>
-            )}
-          {symptomReport.contactBullets &&
-            symptomReport.contactBullets.length > 0 && (
-              <comps.Panel>
-                <comps.Header color={colors.moderate}>
-                  <comps.Title>{symptomReport.contactBulletTitle}</comps.Title>
-                </comps.Header>
-                {symptomReport.contactBullets.map((bullet) => (
-                  <comps.Conclusion key={bullet.bulletUniqueId}>
-                    <comps.BodyText>{bullet.displayText}</comps.BodyText>
-                  </comps.Conclusion>
-                ))}
-              </comps.Panel>
-            )}
+          <BulletsPanel
+            bullets={dangerBullets}
+            title={dangerBulletTitle}
+            headerColor={colors.danger}
+            components={comps}
+          />
+          <BulletsPanel
+            bullets={contactBullets}
+            title={contactBulletTitle}
+            headerColor={colors.moderate}
+            components={comps}
+          />
         </comps.Container>
         <comps.Container key="concs">
-          {symptomReport.reasonConclusions &&
-            symptomReport.reasonConclusions.length > 0 && (
-              <comps.Panel>
-                <comps.Header color={colors.brand100}>
-                  <comps.Title>
-                    {symptomReport.reasonConclusionTitle}
-                  </comps.Title>
-                </comps.Header>
-                {symptomReport.reasonConclusions.map((conclusion) => (
-                  <comps.Conclusion key={conclusion.assetId}>
-                    <comps.ConclusionTitle>
-                      {conclusion.displayText}
-                    </comps.ConclusionTitle>
-                    <comps.Info
-                      onClick={actions.showExplanation}
-                      explanation={conclusion.explanation}
-                    />
-                    <comps.BodyText>{conclusion.truncated}</comps.BodyText>
-                  </comps.Conclusion>
-                ))}
-              </comps.Panel>
-            )}
-          {symptomReport.otherConclusions &&
-            symptomReport.otherConclusions.length > 0 && (
-              <comps.Panel>
-                <comps.Header color={colors.brand100}>
-                  <comps.Title>
-                    {symptomReport.otherConclusionTitle}
-                  </comps.Title>
-                </comps.Header>
-                {symptomReport.otherConclusions.map((conclusion) => (
-                  <comps.Conclusion key={conclusion.assetId}>
-                    <comps.ConclusionTitle>
-                      {conclusion.displayText}
-                    </comps.ConclusionTitle>
-                    <comps.Info
-                      onClick={actions.showExplanation}
-                      explanation={conclusion.explanation}
-                    />
-                  </comps.Conclusion>
-                ))}
-              </comps.Panel>
-            )}
-          {symptomReport.informationConclusions &&
-            symptomReport.informationConclusions.length > 0 && (
-              <comps.Panel>
-                <comps.Header color={colors.brand100}>
-                  <comps.Title>
-                    {symptomReport.informationConclusionTitle}
-                  </comps.Title>
-                </comps.Header>
-                {symptomReport.informationConclusions.map((conclusion) => (
-                  <comps.Conclusion key={conclusion.assetId}>
-                    <comps.ConclusionTitle>
-                      {conclusion.displayText}
-                    </comps.ConclusionTitle>
-                    <comps.Info
-                      onClick={actions.showExplanation}
-                      explanation={conclusion.explanation}
-                    />
-                  </comps.Conclusion>
-                ))}
-              </comps.Panel>
-            )}
+          <ConclusionsPanel
+            showTruncated
+            conclusions={reasonConclusions}
+            title={reasonConclusionTitle}
+            headerColor={colors.brand100}
+            actions={actions}
+            components={comps}
+          />
+          <ConclusionsPanel
+            conclusions={otherConclusions}
+            title={otherConclusionTitle}
+            headerColor={colors.brand100}
+            actions={actions}
+            components={comps}
+          />
+          <ConclusionsPanel
+            conclusions={informationConclusions}
+            title={informationConclusionTitle}
+            headerColor={colors.brand100}
+            actions={actions}
+            components={comps}
+          />
         </comps.Container>
         <comps.Container key="reasons">
-          {symptomReport.reasonBullets &&
-            symptomReport.reasonBullets.length > 0 && (
-              <comps.Panel>
-                <comps.Header color={colors.lightBlue100}>
-                  <comps.Title>{symptomReport.reasonBulletTitle}</comps.Title>
-                </comps.Header>
-                {symptomReport.reasonBullets.map((bullet, i) => (
-                  <comps.Conclusion key={bullet.bulletUniqueId}>
-                    <comps.BodyText bold={i === 0}>
-                      {bullet.displayText}
-                    </comps.BodyText>
-                  </comps.Conclusion>
-                ))}
-              </comps.Panel>
-            )}
+          <BulletsPanel
+            bullets={reasonBullets}
+            title={reasonBulletTitle}
+            headerColor={colors.lightBlue100}
+            firstItemBold
+            components={comps}
+          />
         </comps.Container>
       </comps.Blocks>
     </>

--- a/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReport.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReport.tsx
@@ -1,6 +1,5 @@
 import { SymptomReportModel } from '@doctorlink/traversal-core';
 import React from 'react';
-import colors from '../../Theme/base/colors';
 import { BulletsPanel } from './BulletsPanel';
 import { ConclusionsPanel } from './ConclusionsPanel';
 import {
@@ -10,6 +9,7 @@ import {
 import { MessagePanel } from './MessagePanel';
 import { SymptomReportCallbacks } from './SymptomReportCallbacks';
 import { SymptomReportComponents } from './SymptomReportComponents';
+import { useTheme } from 'styled-components';
 
 export const SymptomReport: React.FC<{
   symptomReport: SymptomReportModel;
@@ -21,6 +21,7 @@ export const SymptomReport: React.FC<{
   components = defaultSymptomReportComponents,
 }) => {
   const comps = { ...defaultSymptomReportComponents, ...components };
+  const theme = useTheme();
 
   const {
     dangerBullets,
@@ -36,6 +37,7 @@ export const SymptomReport: React.FC<{
     reasonBullets,
     reasonBulletTitle,
   } = symptomReport;
+  const { panelHeaders } = theme.symptomReport;
 
   return (
     <comps.Blocks key="panel" staggerChildren={0.2} style={{ margin: 0 }}>
@@ -43,14 +45,14 @@ export const SymptomReport: React.FC<{
       <ConclusionsPanel
         conclusions={reasonConclusions}
         title={reasonConclusionTitle}
-        headerColor={colors.brand100}
+        headerColor={panelHeaders.reasonConclusions}
         actions={actions}
         components={comps}
       />
       <ConclusionsPanel
         conclusions={otherConclusions}
         title={otherConclusionTitle}
-        headerColor={colors.brand100}
+        headerColor={panelHeaders.otherConclusions}
         actions={actions}
         components={comps}
       />
@@ -58,21 +60,21 @@ export const SymptomReport: React.FC<{
         collapse
         bullets={dangerBullets}
         title={dangerBulletTitle}
-        headerColor={colors.danger}
+        headerColor={panelHeaders.dangerBullets}
         components={comps}
       />
       <BulletsPanel
         collapse
         bullets={contactBullets}
         title={contactBulletTitle}
-        headerColor={colors.moderate}
+        headerColor={panelHeaders.contactBullets}
         components={comps}
       />
       <BulletsPanel
         collapse
         bullets={reasonBullets}
         title={reasonBulletTitle}
-        headerColor={colors.lightBlue100}
+        headerColor={panelHeaders.reasonBullets}
         firstItemBold
         components={comps}
       />
@@ -80,7 +82,7 @@ export const SymptomReport: React.FC<{
         collapse
         conclusions={informationConclusions}
         title={informationConclusionTitle}
-        headerColor={colors.brand100}
+        headerColor={panelHeaders.informationConclusions}
         actions={actions}
         components={comps}
       />

--- a/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReport.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReport.tsx
@@ -14,7 +14,7 @@ import { SymptomReportComponents } from './SymptomReportComponents';
 export const SymptomReport: React.FC<{
   symptomReport: SymptomReportModel;
   actions?: SymptomReportCallbacks;
-  components?: SymptomReportComponents;
+  components?: Partial<SymptomReportComponents>;
 }> = ({
   symptomReport,
   actions = defaultSymptomReportActions,
@@ -38,59 +38,53 @@ export const SymptomReport: React.FC<{
   } = symptomReport;
 
   return (
-    <>
-      <comps.Blocks key="panel" staggerChildren={0.2} style={{ margin: 0 }}>
-        <MessagePanel symptomReport={symptomReport} components={components} />
-      </comps.Blocks>
-      <comps.Blocks key="bullets" staggerChildren={0.2}>
-        <comps.Container float={'right'}>
-          <BulletsPanel
-            bullets={dangerBullets}
-            title={dangerBulletTitle}
-            headerColor={colors.danger}
-            components={comps}
-          />
-          <BulletsPanel
-            bullets={contactBullets}
-            title={contactBulletTitle}
-            headerColor={colors.moderate}
-            components={comps}
-          />
-        </comps.Container>
-        <comps.Container key="concs">
-          <ConclusionsPanel
-            showTruncated
-            conclusions={reasonConclusions}
-            title={reasonConclusionTitle}
-            headerColor={colors.brand100}
-            actions={actions}
-            components={comps}
-          />
-          <ConclusionsPanel
-            conclusions={otherConclusions}
-            title={otherConclusionTitle}
-            headerColor={colors.brand100}
-            actions={actions}
-            components={comps}
-          />
-          <ConclusionsPanel
-            conclusions={informationConclusions}
-            title={informationConclusionTitle}
-            headerColor={colors.brand100}
-            actions={actions}
-            components={comps}
-          />
-        </comps.Container>
-        <comps.Container key="reasons">
-          <BulletsPanel
-            bullets={reasonBullets}
-            title={reasonBulletTitle}
-            headerColor={colors.lightBlue100}
-            firstItemBold
-            components={comps}
-          />
-        </comps.Container>
-      </comps.Blocks>
-    </>
+    <comps.Blocks key="panel" staggerChildren={0.2} style={{ margin: 0 }}>
+      <MessagePanel symptomReport={symptomReport} components={comps} />
+      <ConclusionsPanel
+        showTruncated
+        conclusions={reasonConclusions}
+        title={reasonConclusionTitle}
+        headerColor={colors.brand100}
+        actions={actions}
+        components={comps}
+      />
+      <ConclusionsPanel
+        conclusions={otherConclusions}
+        title={otherConclusionTitle}
+        headerColor={colors.brand100}
+        actions={actions}
+        components={comps}
+      />
+      <BulletsPanel
+        collapse
+        bullets={dangerBullets}
+        title={dangerBulletTitle}
+        headerColor={colors.danger}
+        components={comps}
+      />
+      <BulletsPanel
+        collapse
+        bullets={contactBullets}
+        title={contactBulletTitle}
+        headerColor={colors.moderate}
+        components={comps}
+      />
+      <BulletsPanel
+        collapse
+        bullets={reasonBullets}
+        title={reasonBulletTitle}
+        headerColor={colors.lightBlue100}
+        firstItemBold
+        components={comps}
+      />
+      <ConclusionsPanel
+        collapse
+        conclusions={informationConclusions}
+        title={informationConclusionTitle}
+        headerColor={colors.brand100}
+        actions={actions}
+        components={comps}
+      />
+    </comps.Blocks>
   );
 };

--- a/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReport.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReport.tsx
@@ -41,7 +41,6 @@ export const SymptomReport: React.FC<{
     <comps.Blocks key="panel" staggerChildren={0.2} style={{ margin: 0 }}>
       <MessagePanel symptomReport={symptomReport} components={comps} />
       <ConclusionsPanel
-        showTruncated
         conclusions={reasonConclusions}
         title={reasonConclusionTitle}
         headerColor={colors.brand100}

--- a/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReport.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReport.tsx
@@ -1,14 +1,17 @@
+import { SymptomReportModel } from '@doctorlink/traversal-core';
 import React from 'react';
 import colors from '../../Theme/base/colors';
 import {
   defaultSymptomReportActions,
   defaultSymptomReportComponents,
 } from './defaults';
+import { SymptomReportCallbacks } from './SymptomReportCallbacks';
+import { SymptomReportComponents } from './SymptomReportComponents';
 
 export const SymptomReport: React.FC<{
-  symptomReport: any;
-  actions?: any;
-  components?: any;
+  symptomReport: SymptomReportModel;
+  actions?: SymptomReportCallbacks;
+  components?: SymptomReportComponents;
 }> = ({
   symptomReport,
   actions = defaultSymptomReportActions,
@@ -30,7 +33,7 @@ export const SymptomReport: React.FC<{
   return (
     <>
       <comps.Blocks key="panel" staggerChildren={0.2} style={{ margin: 0 }}>
-        <comps.Panel fullWidth={true} key="header" id="Traversal">
+        <comps.Panel key="header" id="Traversal">
           <comps.Header color={level()}>
             <comps.Icon state={symptomReport.messageLevel} />
             <comps.Title>{symptomReport.messageTitle}</comps.Title>
@@ -52,8 +55,8 @@ export const SymptomReport: React.FC<{
                 <comps.Header color={colors.danger}>
                   <comps.Title>{symptomReport.dangerBulletTitle}</comps.Title>
                 </comps.Header>
-                {symptomReport.dangerBullets.map((bullet: any, i: any) => (
-                  <comps.Conclusion key={i}>
+                {symptomReport.dangerBullets.map((bullet) => (
+                  <comps.Conclusion key={bullet.bulletUniqueId}>
                     <comps.BodyText>{bullet.displayText}</comps.BodyText>
                   </comps.Conclusion>
                 ))}
@@ -65,8 +68,8 @@ export const SymptomReport: React.FC<{
                 <comps.Header color={colors.moderate}>
                   <comps.Title>{symptomReport.contactBulletTitle}</comps.Title>
                 </comps.Header>
-                {symptomReport.contactBullets.map((bullet: any, i: any) => (
-                  <comps.Conclusion key={i}>
+                {symptomReport.contactBullets.map((bullet) => (
+                  <comps.Conclusion key={bullet.bulletUniqueId}>
                     <comps.BodyText>{bullet.displayText}</comps.BodyText>
                   </comps.Conclusion>
                 ))}
@@ -82,20 +85,18 @@ export const SymptomReport: React.FC<{
                     {symptomReport.reasonConclusionTitle}
                   </comps.Title>
                 </comps.Header>
-                {symptomReport.reasonConclusions.map(
-                  (conclusion: any, i: any) => (
-                    <comps.Conclusion key={i}>
-                      <comps.ConclusionTitle>
-                        {conclusion.displayText}
-                      </comps.ConclusionTitle>
-                      <comps.Info
-                        onClick={actions.showExplanation}
-                        explanation={conclusion.explanation}
-                      />
-                      <comps.BodyText>{conclusion.truncated}</comps.BodyText>
-                    </comps.Conclusion>
-                  )
-                )}
+                {symptomReport.reasonConclusions.map((conclusion) => (
+                  <comps.Conclusion key={conclusion.assetId}>
+                    <comps.ConclusionTitle>
+                      {conclusion.displayText}
+                    </comps.ConclusionTitle>
+                    <comps.Info
+                      onClick={actions.showExplanation}
+                      explanation={conclusion.explanation}
+                    />
+                    <comps.BodyText>{conclusion.truncated}</comps.BodyText>
+                  </comps.Conclusion>
+                ))}
               </comps.Panel>
             )}
           {symptomReport.otherConclusions &&
@@ -106,19 +107,17 @@ export const SymptomReport: React.FC<{
                     {symptomReport.otherConclusionTitle}
                   </comps.Title>
                 </comps.Header>
-                {symptomReport.otherConclusions.map(
-                  (conclusion: any, i: any) => (
-                    <comps.Conclusion key={i}>
-                      <comps.ConclusionTitle>
-                        {conclusion.displayText}
-                      </comps.ConclusionTitle>
-                      <comps.Info
-                        onClick={actions.showExplanation}
-                        explanation={conclusion.explanation}
-                      />
-                    </comps.Conclusion>
-                  )
-                )}
+                {symptomReport.otherConclusions.map((conclusion) => (
+                  <comps.Conclusion key={conclusion.assetId}>
+                    <comps.ConclusionTitle>
+                      {conclusion.displayText}
+                    </comps.ConclusionTitle>
+                    <comps.Info
+                      onClick={actions.showExplanation}
+                      explanation={conclusion.explanation}
+                    />
+                  </comps.Conclusion>
+                ))}
               </comps.Panel>
             )}
           {symptomReport.informationConclusions &&
@@ -129,19 +128,17 @@ export const SymptomReport: React.FC<{
                     {symptomReport.informationConclusionTitle}
                   </comps.Title>
                 </comps.Header>
-                {symptomReport.informationConclusions.map(
-                  (conclusion: any, i: any) => (
-                    <comps.Conclusion key={i}>
-                      <comps.ConclusionTitle>
-                        {conclusion.displayText}
-                      </comps.ConclusionTitle>
-                      <comps.Info
-                        onClick={actions.showExplanation}
-                        explanation={conclusion.explanation}
-                      />
-                    </comps.Conclusion>
-                  )
-                )}
+                {symptomReport.informationConclusions.map((conclusion) => (
+                  <comps.Conclusion key={conclusion.assetId}>
+                    <comps.ConclusionTitle>
+                      {conclusion.displayText}
+                    </comps.ConclusionTitle>
+                    <comps.Info
+                      onClick={actions.showExplanation}
+                      explanation={conclusion.explanation}
+                    />
+                  </comps.Conclusion>
+                ))}
               </comps.Panel>
             )}
         </comps.Container>
@@ -152,8 +149,8 @@ export const SymptomReport: React.FC<{
                 <comps.Header color={colors.lightBlue100}>
                   <comps.Title>{symptomReport.reasonBulletTitle}</comps.Title>
                 </comps.Header>
-                {symptomReport.reasonBullets.map((bullet: any, i: any) => (
-                  <comps.Conclusion key={i}>
+                {symptomReport.reasonBullets.map((bullet, i) => (
+                  <comps.Conclusion key={bullet.bulletUniqueId}>
                     <comps.BodyText bold={i === 0}>
                       {bullet.displayText}
                     </comps.BodyText>

--- a/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReportComponents.ts
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReportComponents.ts
@@ -2,9 +2,10 @@ import { HTMLMotionProps } from 'framer-motion';
 import { ComponentType, HTMLAttributes } from 'react';
 import { InfoIconProps } from '../../Components';
 import { PanelBlocksProps } from '../../Components/PanelBlocks';
-import { PanelBodyTextProps } from '../../Components/PanelBodyText/PanelBodyText';
+import { PanelBodyTextProps } from '../../Components/PanelBodyText';
 import { PanelContainerProps } from '../../Components/PanelContainer';
 import { PanelHeaderProps } from '../../Components/PanelHeader';
+import { PanelTitleProps } from '../../Components/PanelTitle';
 import { IconProps } from './Icon';
 
 export interface SymptomReportComponents {
@@ -13,7 +14,7 @@ export interface SymptomReportComponents {
   Panel: ComponentType<HTMLMotionProps<'div'>>;
   Header: ComponentType<PanelHeaderProps>;
   Icon: ComponentType<IconProps>;
-  Title: ComponentType;
+  Title: ComponentType<PanelTitleProps>;
   Content: ComponentType;
   BodyText: ComponentType<PanelBodyTextProps & HTMLAttributes<HTMLDivElement>>;
   Conclusion: ComponentType;

--- a/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReportComponents.ts
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReportComponents.ts
@@ -22,4 +22,5 @@ export interface SymptomReportComponents {
   ConclusionTitle: ComponentType;
   Info: ComponentType<InfoIconProps>;
   Message: ComponentType<SymptomReportMessageProps>;
+  MessageTitle: ComponentType;
 }

--- a/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReportComponents.ts
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReportComponents.ts
@@ -6,6 +6,7 @@ import { PanelBodyTextProps } from '../../Components/PanelBodyText';
 import { PanelContainerProps } from '../../Components/PanelContainer';
 import { PanelHeaderProps } from '../../Components/PanelHeader';
 import { PanelTitleProps } from '../../Components/PanelTitle';
+import { SymptomReportMessageProps } from '../../Components/SymptomReportMessage';
 import { IconProps } from './Icon';
 
 export interface SymptomReportComponents {
@@ -20,4 +21,5 @@ export interface SymptomReportComponents {
   Conclusion: ComponentType;
   ConclusionTitle: ComponentType;
   Info: ComponentType<InfoIconProps>;
+  Message: ComponentType<SymptomReportMessageProps>;
 }

--- a/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReportComponents.ts
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/SymptomReportComponents.ts
@@ -1,0 +1,22 @@
+import { HTMLMotionProps } from 'framer-motion';
+import { ComponentType, HTMLAttributes } from 'react';
+import { InfoIconProps } from '../../Components';
+import { PanelBlocksProps } from '../../Components/PanelBlocks';
+import { PanelBodyTextProps } from '../../Components/PanelBodyText/PanelBodyText';
+import { PanelContainerProps } from '../../Components/PanelContainer';
+import { PanelHeaderProps } from '../../Components/PanelHeader';
+import { IconProps } from './Icon';
+
+export interface SymptomReportComponents {
+  Blocks: ComponentType<PanelBlocksProps>;
+  Container: ComponentType<PanelContainerProps>;
+  Panel: ComponentType<HTMLMotionProps<'div'>>;
+  Header: ComponentType<PanelHeaderProps>;
+  Icon: ComponentType<IconProps>;
+  Title: ComponentType;
+  Content: ComponentType;
+  BodyText: ComponentType<PanelBodyTextProps & HTMLAttributes<HTMLDivElement>>;
+  Conclusion: ComponentType;
+  ConclusionTitle: ComponentType;
+  Info: ComponentType<InfoIconProps>;
+}

--- a/packages/styled-components/src/ComponentModules/SymptomReport/defaults.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/defaults.tsx
@@ -10,6 +10,7 @@ import {
   PanelBodyText as BodyText,
   PanelConclusionTitle as ConclusionTitle,
   SymptomReportMessage as Message,
+  SymptomReportMessageTitle as MessageTitle,
 } from '../../Components';
 import { SymptomReportCallbacks } from './SymptomReportCallbacks';
 import { Icon } from './Icon';
@@ -28,6 +29,7 @@ export const defaultSymptomReportComponents: SymptomReportComponents = {
   ConclusionTitle,
   Info,
   Message,
+  MessageTitle,
 };
 
 export const defaultSymptomReportActions: SymptomReportCallbacks = {

--- a/packages/styled-components/src/ComponentModules/SymptomReport/defaults.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/defaults.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import {
-  InfoIcon,
+  InfoIcon as Info,
   PanelBlocks as Blocks,
   PanelContainer as Container,
   Panel,
@@ -10,42 +9,12 @@ import {
   PanelConclusion as Conclusion,
   PanelBodyText as BodyText,
   PanelConclusionTitle as ConclusionTitle,
-  PanelSVG,
 } from '../../Components';
 import { SymptomReportCallbacks } from './SymptomReportCallbacks';
+import { Icon } from './Icon';
+import { SymptomReportComponents } from './SymptomReportComponents';
 
-const Icon: React.FC<{ state: any }> = ({ state }) => {
-  if (state === 1)
-    return (
-      <PanelSVG width="24" height="24" viewBox="0 0 24 24">
-        <circle cx="12" cy="12" r="10"></circle>
-        <line x1="12" y1="8" x2="12" y2="12"></line>
-        <line x1="12" y1="16" x2="12" y2="16"></line>
-      </PanelSVG>
-    );
-
-  if (state === 2)
-    return (
-      <PanelSVG width="24" height="24" viewBox="0 0 24 24">
-        <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
-        <line x1="12" y1="9" x2="12" y2="13"></line>
-        <line x1="12" y1="17" x2="12" y2="17"></line>
-      </PanelSVG>
-    );
-
-  return (
-    <PanelSVG width="24" height="24" viewBox="0 0 24 24">
-      <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
-      <polyline points="22 4 12 14.01 9 11.01"></polyline>
-    </PanelSVG>
-  );
-};
-
-const Info: React.FC<any> = ({ ...props }) => (
-  <InfoIcon inline={true} {...props} />
-);
-
-export const defaultSymptomReportComponents = {
+export const defaultSymptomReportComponents: SymptomReportComponents = {
   Blocks,
   Container,
   Panel,

--- a/packages/styled-components/src/ComponentModules/SymptomReport/defaults.tsx
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/defaults.tsx
@@ -9,6 +9,7 @@ import {
   PanelConclusion as Conclusion,
   PanelBodyText as BodyText,
   PanelConclusionTitle as ConclusionTitle,
+  SymptomReportMessage as Message,
 } from '../../Components';
 import { SymptomReportCallbacks } from './SymptomReportCallbacks';
 import { Icon } from './Icon';
@@ -26,6 +27,7 @@ export const defaultSymptomReportComponents: SymptomReportComponents = {
   Conclusion,
   ConclusionTitle,
   Info,
+  Message,
 };
 
 export const defaultSymptomReportActions: SymptomReportCallbacks = {

--- a/packages/styled-components/src/ComponentModules/SymptomReport/index.ts
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/index.ts
@@ -1,4 +1,5 @@
 export * from './SymptomReport';
 export * from './defaults';
 export * from './SymptomReportCallbacks';
+export * from './SymptomReportComponents';
 export * from './useSymptomReportActions';

--- a/packages/styled-components/src/ComponentModules/SymptomReport/useMessageColor.ts
+++ b/packages/styled-components/src/ComponentModules/SymptomReport/useMessageColor.ts
@@ -1,0 +1,14 @@
+import { useTheme } from 'styled-components';
+
+export const useMessageColor = (level: number): string => {
+  const theme = useTheme();
+  const { message } = theme.symptomReport;
+  switch (level) {
+    case 3:
+      return message.colorNormal;
+    case 2:
+      return message.colorModerate;
+    default:
+      return message.colorDanger;
+  }
+};

--- a/packages/styled-components/src/Components/Accordion/AccordionBody.tsx
+++ b/packages/styled-components/src/Components/Accordion/AccordionBody.tsx
@@ -1,22 +1,23 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
-
-const StyledBody = styled.div`
-  padding-top: 1.5rem;
-`;
 
 const Expandable = styled.div`
   overflow: hidden;
   transition: height 0.3s;
 `;
 
-const AccordionBody: React.FC<{ open: any }> = ({ open, children }) => {
-  const ref = useRef<HTMLElement>();
-  const scrollHeight = ref.current && ref.current.scrollHeight;
+const AccordionBody: React.FC<{ open: boolean }> = ({ open, children }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [scrollHeight, setScrollHeight] = useState<number>();
+
+  useEffect(() => {
+    setScrollHeight(ref.current?.scrollHeight);
+  }, [ref.current]);
+
   const height = open ? scrollHeight : 0;
   return (
-    <Expandable ref={ref as any} style={{ height }}>
-      <StyledBody>{children}</StyledBody>
+    <Expandable ref={ref} style={{ height }}>
+      {children}
     </Expandable>
   );
 };

--- a/packages/styled-components/src/Components/Accordion/AccordionHeader.tsx
+++ b/packages/styled-components/src/Components/Accordion/AccordionHeader.tsx
@@ -7,6 +7,7 @@ const StyledHeader = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  width: 100%;
 `;
 
 interface AccordionHeaderProps {
@@ -21,7 +22,7 @@ const AccordionHeader: React.FC<AccordionHeaderProps> = ({
 }) => (
   <StyledHeader onClick={toggleOpen}>
     {children}
-    <OpenIcon open={open} />
+    <OpenIcon open={open} onClick={toggleOpen} />
   </StyledHeader>
 );
 

--- a/packages/styled-components/src/Components/Accordion/OpenIcon.tsx
+++ b/packages/styled-components/src/Components/Accordion/OpenIcon.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 import colors from '../../Theme/base/colors';
+import IconButton from '../IconButton';
 
-const StyledDiv = styled.div`
-  width: 16px;
-  height: 16px;
+const Svg = styled.svg`
+  width: 100%;
+  height: 100%;
 `;
 
 const StyledPolyline = styled.polyline`
@@ -14,21 +15,31 @@ const StyledPolyline = styled.polyline`
   stroke-linecap: round;
   stroke-linejoin: miter;
   transition: transform 0.3s;
-  transform-origin: 7px 8px;
+  transform-origin: 8px 8px;
 
   &.open {
-    transform: rotate(90deg);
+    transform: rotate(180deg);
   }
 `;
 
-const OpenIcon: React.FC<{ open: boolean }> = ({ open }) => {
+const Button = styled(IconButton)`
+  width: 16px;
+  height: 16px;
+`;
+
+export interface OpenIconProps {
+  open: boolean;
+  onClick: () => void;
+}
+
+const OpenIcon: React.FC<OpenIconProps> = ({ open, onClick }) => {
   const className = open ? 'open' : 'closed';
   return (
-    <StyledDiv>
-      <svg viewBox="0 0 16 16">
-        <StyledPolyline className={className} points="5 2, 11 8, 5 14" />
-      </svg>
-    </StyledDiv>
+    <Button onClick={onClick}>
+      <Svg viewBox="0 0 16 16">
+        <StyledPolyline className={className} points="2 5, 8 11, 14 5" />
+      </Svg>
+    </Button>
   );
 };
 

--- a/packages/styled-components/src/Components/Panel/Panel.tsx
+++ b/packages/styled-components/src/Components/Panel/Panel.tsx
@@ -8,12 +8,8 @@ const StyledPanel = styled(motion.div)`
     0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 2px 1px -1px rgba(0, 0, 0, 0.12);
   margin-bottom: 30px;
   overflow: hidden;
-  @media screen and (max-width: 799px) {
-    border-radius: 0 0 8px 8px;
-  }
-  @media screen and (min-width: 800px) {
-    border-radius: 8px;
-  }
+  border: 1px solid #dbdbdb;
+  border-radius: 8px;
 `;
 
 const variants = {

--- a/packages/styled-components/src/Components/Panel/Panel.tsx
+++ b/packages/styled-components/src/Components/Panel/Panel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { motion } from 'framer-motion';
+import { motion, HTMLMotionProps } from 'framer-motion';
 
 const StyledPanel = styled(motion.div)`
   background-color: white;
@@ -21,7 +21,10 @@ const variants = {
   hide: { opacity: 0, y: '250px' },
 };
 
-export const Panel: React.FC<any> = ({ children, ...props }) => (
+export const Panel: React.FC<HTMLMotionProps<'div'>> = ({
+  children,
+  ...props
+}) => (
   <StyledPanel variants={variants} {...props}>
     {children}
   </StyledPanel>

--- a/packages/styled-components/src/Components/PanelBlocks/PanelBlocks.tsx
+++ b/packages/styled-components/src/Components/PanelBlocks/PanelBlocks.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion, HTMLMotionProps } from 'framer-motion';
 
-export const PanelBlocks: React.FC<any> = ({
+export interface PanelBlocksProps extends HTMLMotionProps<'div'> {
+  staggerChildren?: number;
+}
+
+export const PanelBlocks: React.FC<PanelBlocksProps> = ({
   children,
   staggerChildren = 0,
   ...props

--- a/packages/styled-components/src/Components/PanelBlocks/index.ts
+++ b/packages/styled-components/src/Components/PanelBlocks/index.ts
@@ -1,1 +1,1 @@
-export { default } from './PanelBlocks';
+export { default, PanelBlocksProps } from './PanelBlocks';

--- a/packages/styled-components/src/Components/PanelBodyText/PanelBodyText.ts
+++ b/packages/styled-components/src/Components/PanelBodyText/PanelBodyText.ts
@@ -1,9 +1,10 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { defaultTheme } from '../../Theme';
 
 export interface PanelBodyTextProps {
   readonly bold?: boolean;
   contrastText?: boolean;
+  bullet?: 'default' | 'warning';
 }
 
 export const PanelBodyText = styled.div<PanelBodyTextProps>`
@@ -15,6 +16,23 @@ export const PanelBodyText = styled.div<PanelBodyTextProps>`
   font-family: ${(p) => p.theme.panelbodytext.fontFamily};
   line-height: ${(p) => p.theme.panelbodytext.lineHeight}px;
   font-weight: ${(p) => (p.bold ? 'bold' : 'normal')};
+
+  ${(p) =>
+    p.bullet &&
+    css`
+      display: list-item;
+      margin-left: 14px;
+    `}
+
+  ${(p) => {
+    const size = p.theme.panelbodytext.fontSize;
+    return (
+      p.bullet === 'warning' &&
+      css`
+      list-style: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='${size}px' width='${size}px' viewBox='0 0 24 20' fill='none' stroke='%23ff6c6c' stroke-width='2'%3E%3Cpath d='M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z'%3E%3C/path%3E%3Cline x1='12' y1='9' x2='12' y2='14'%3E%3C/line%3E%3Cline x1='12' y1='16.5' x2='12' y2='18'%3E%3C/line%3E%3C/svg%3E");
+    `
+    );
+  }}
 `;
 
 PanelBodyText.defaultProps = {

--- a/packages/styled-components/src/Components/PanelBodyText/PanelBodyText.ts
+++ b/packages/styled-components/src/Components/PanelBodyText/PanelBodyText.ts
@@ -11,7 +11,7 @@ export const PanelBodyText = styled.div<PanelBodyTextProps>`
   margin: 0;
   display: block;
   color: ${(p) =>
-    p.contrastText ? p.theme.colors.white : 'rgba(0, 0, 0, 0.87)'};
+    p.contrastText ? p.theme.colors.white : p.theme.panelbodytext.color};
   font-size: ${(p) => p.theme.panelbodytext.fontSize}px;
   font-family: ${(p) => p.theme.panelbodytext.fontFamily};
   line-height: ${(p) => p.theme.panelbodytext.lineHeight}px;

--- a/packages/styled-components/src/Components/PanelBodyText/index.ts
+++ b/packages/styled-components/src/Components/PanelBodyText/index.ts
@@ -1,1 +1,1 @@
-export { default } from './PanelBodyText';
+export { default, PanelBodyTextProps } from './PanelBodyText';

--- a/packages/styled-components/src/Components/PanelContainer/PanelContainer.tsx
+++ b/packages/styled-components/src/Components/PanelContainer/PanelContainer.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
-import { motion } from 'framer-motion';
+import { HTMLMotionProps, motion } from 'framer-motion';
 
-export interface PanelContainerProps {
-  float: string;
+export interface PanelContainerProps extends HTMLMotionProps<'div'> {
+  float?: string;
 }
 
 const Styled = styled(motion.div)<PanelContainerProps>`
@@ -26,7 +26,10 @@ const variants = {
   hide: { opacity: 0, y: '250px' },
 };
 
-export const Panel: React.FC<any> = ({ children, ...props }) => (
+export const Panel: React.FC<PanelContainerProps> = ({
+  children,
+  ...props
+}) => (
   <Styled variants={variants} {...props}>
     {children}
   </Styled>

--- a/packages/styled-components/src/Components/PanelContainer/index.ts
+++ b/packages/styled-components/src/Components/PanelContainer/index.ts
@@ -1,1 +1,1 @@
-export { default } from './PanelContainer';
+export { default, PanelContainerProps } from './PanelContainer';

--- a/packages/styled-components/src/Components/PanelHeader/PanelHeader.ts
+++ b/packages/styled-components/src/Components/PanelHeader/PanelHeader.ts
@@ -1,7 +1,11 @@
 import styled from 'styled-components';
 import { defaultTheme } from '../../Theme';
 
-const PanelHeader = styled.div`
+export interface PanelHeaderProps {
+  color?: string;
+}
+
+const PanelHeader = styled.div<PanelHeaderProps>`
   box-sizing: border-box;
   display: flex;
   align-items: center;

--- a/packages/styled-components/src/Components/PanelHeader/index.ts
+++ b/packages/styled-components/src/Components/PanelHeader/index.ts
@@ -1,1 +1,1 @@
-export { default } from './PanelHeader';
+export { default, PanelHeaderProps } from './PanelHeader';

--- a/packages/styled-components/src/Components/PanelSVG/PanelSVG.ts
+++ b/packages/styled-components/src/Components/PanelSVG/PanelSVG.ts
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 export default styled.svg`
   fill: none;
-  stroke: white;
   stroke-width: 3px;
   stroke-linecap: round;
   stroke-linejoin: round;

--- a/packages/styled-components/src/Components/PanelTitle/PanelTitle.ts
+++ b/packages/styled-components/src/Components/PanelTitle/PanelTitle.ts
@@ -7,8 +7,7 @@ export interface PanelTitleProps {
 
 const PanelTitle = styled.div<PanelTitleProps>`
   color: ${(p) => p.color || 'white'};
-  font-size: 0.875rem;
-  font-weight: 400;
+  font-weight: ${(p) => p.theme.paneltitle.fontWeight};
   font-size: ${(p) => p.theme.paneltitle.fontSize}px;
   font-family: ${(p) => p.theme.paneltitle.fontFamily};
   line-height: ${(p) => p.theme.paneltitle.lineHeight}px;

--- a/packages/styled-components/src/Components/PanelTitle/PanelTitle.ts
+++ b/packages/styled-components/src/Components/PanelTitle/PanelTitle.ts
@@ -1,7 +1,11 @@
 import styled from 'styled-components';
 import { defaultTheme } from '../../Theme';
 
-const PanelTitle = styled.div`
+export interface PanelTitleProps {
+  color?: string;
+}
+
+const PanelTitle = styled.div<PanelTitleProps>`
   color: ${(p) => p.color || 'white'};
   font-size: 0.875rem;
   font-weight: 400;

--- a/packages/styled-components/src/Components/PanelTitle/index.ts
+++ b/packages/styled-components/src/Components/PanelTitle/index.ts
@@ -1,1 +1,1 @@
-export { default } from './PanelTitle';
+export { default, PanelTitleProps } from './PanelTitle';

--- a/packages/styled-components/src/Components/SymptomReportMessage/SymptomReportMessage.tsx
+++ b/packages/styled-components/src/Components/SymptomReportMessage/SymptomReportMessage.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from 'styled-components';
+import { motion } from 'framer-motion';
+import { SymptomReportTheme } from '../../Theme/components/symptomReport';
+
+export interface SymptomReportMessageProps {
+  level: number;
+}
+
+const background = (level: number, theme: SymptomReportTheme) => {
+  switch (level) {
+    case 3:
+      return theme.message.backgroundNormal;
+    case 2:
+      return theme.message.backgroundModerate;
+    default:
+      return theme.message.backgroundDanger;
+  }
+};
+
+const StyledPanel = styled(motion.div)<SymptomReportMessageProps>`
+  background: ${(p) => background(p.level, p.theme.symptomReport)};
+  box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.2),
+    0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 2px 1px -1px rgba(0, 0, 0, 0.12);
+  margin-bottom: 30px;
+  overflow: hidden;
+  border-radius: 8px;
+`;
+
+const variants = {
+  show: { opacity: 1, y: 0 },
+  hide: { opacity: 0, y: '250px' },
+};
+
+export const SymptomReportMessage: React.FC<SymptomReportMessageProps> = ({
+  children,
+  ...props
+}) => (
+  <StyledPanel variants={variants} {...props}>
+    {children}
+  </StyledPanel>
+);

--- a/packages/styled-components/src/Components/SymptomReportMessage/SymptomReportMessage.tsx
+++ b/packages/styled-components/src/Components/SymptomReportMessage/SymptomReportMessage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { motion } from 'framer-motion';
 import { SymptomReportTheme } from '../../Theme/components/symptomReport';
 
@@ -10,21 +10,29 @@ export interface SymptomReportMessageProps {
 const background = (level: number, theme: SymptomReportTheme) => {
   switch (level) {
     case 3:
-      return theme.message.backgroundNormal;
+      return theme.message.colorNormal;
     case 2:
-      return theme.message.backgroundModerate;
+      return theme.message.colorModerate;
     default:
-      return theme.message.backgroundDanger;
+      return theme.message.colorDanger;
   }
 };
 
 const StyledPanel = styled(motion.div)<SymptomReportMessageProps>`
-  background: ${(p) => background(p.level, p.theme.symptomReport)};
   box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.2),
     0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 2px 1px -1px rgba(0, 0, 0, 0.12);
   margin-bottom: 30px;
   overflow: hidden;
+  border: 1px solid #dbdbdb;
   border-radius: 8px;
+
+  ${(p) => {
+    const color = background(p.level, p.theme.symptomReport);
+    return css`
+      border-left: 8px solid ${color};
+      color: ${color};
+    `;
+  }}
 `;
 
 const variants = {

--- a/packages/styled-components/src/Components/SymptomReportMessage/SymptomReportMessage.tsx
+++ b/packages/styled-components/src/Components/SymptomReportMessage/SymptomReportMessage.tsx
@@ -13,7 +13,6 @@ const StyledPanel = styled(motion.div)<SymptomReportMessageProps>`
   border: 1px solid #dbdbdb;
   border-radius: 8px;
   border-left: 8px solid ${(p) => p.color};
-  color: ${(p) => p.color};
 `;
 
 const variants = {

--- a/packages/styled-components/src/Components/SymptomReportMessage/SymptomReportMessage.tsx
+++ b/packages/styled-components/src/Components/SymptomReportMessage/SymptomReportMessage.tsx
@@ -1,23 +1,10 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { motion } from 'framer-motion';
-import { SymptomReportTheme } from '../../Theme/components/symptomReport';
 
 export interface SymptomReportMessageProps {
-  level: number;
+  color: string;
 }
-
-const background = (level: number, theme: SymptomReportTheme) => {
-  switch (level) {
-    case 3:
-      return theme.message.colorNormal;
-    case 2:
-      return theme.message.colorModerate;
-    default:
-      return theme.message.colorDanger;
-  }
-};
-
 const StyledPanel = styled(motion.div)<SymptomReportMessageProps>`
   box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.2),
     0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 2px 1px -1px rgba(0, 0, 0, 0.12);
@@ -25,14 +12,8 @@ const StyledPanel = styled(motion.div)<SymptomReportMessageProps>`
   overflow: hidden;
   border: 1px solid #dbdbdb;
   border-radius: 8px;
-
-  ${(p) => {
-    const color = background(p.level, p.theme.symptomReport);
-    return css`
-      border-left: 8px solid ${color};
-      color: ${color};
-    `;
-  }}
+  border-left: 8px solid ${(p) => p.color};
+  color: ${(p) => p.color};
 `;
 
 const variants = {

--- a/packages/styled-components/src/Components/SymptomReportMessage/SymptomReportMessageTitle.tsx
+++ b/packages/styled-components/src/Components/SymptomReportMessage/SymptomReportMessageTitle.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+export const SymptomReportMessageTitle = styled.div`
+  display: flex;
+  align-items: center;
+  font-weight: ${(p) => p.theme.symptomReport.messageTitle.fontWeight};
+  font-size: ${(p) => p.theme.symptomReport.messageTitle.fontSize}px;
+  font-family: ${(p) => p.theme.symptomReport.messageTitle.fontFamily};
+  line-height: ${(p) => p.theme.symptomReport.messageTitle.lineHeight}px;
+  padding-bottom: ${(p) => p.theme.symptomReport.messageTitle.paddingBottom}px;
+`;

--- a/packages/styled-components/src/Components/SymptomReportMessage/index.ts
+++ b/packages/styled-components/src/Components/SymptomReportMessage/index.ts
@@ -1,1 +1,2 @@
 export * from './SymptomReportMessage';
+export * from './SymptomReportMessageTitle';

--- a/packages/styled-components/src/Components/SymptomReportMessage/index.ts
+++ b/packages/styled-components/src/Components/SymptomReportMessage/index.ts
@@ -1,0 +1,1 @@
+export * from './SymptomReportMessage';

--- a/packages/styled-components/src/Components/index.ts
+++ b/packages/styled-components/src/Components/index.ts
@@ -88,3 +88,4 @@ export { default as CompareNumbers } from './ComparisonReport/CompareNumbers';
 export { default as SummaryDivider } from './SummaryDivider';
 
 export * from './HealthReportExplanation';
+export * from './SymptomReportMessage';

--- a/packages/styled-components/src/Containers/HealthAssessment/Conclusions/Explanations.tsx
+++ b/packages/styled-components/src/Containers/HealthAssessment/Conclusions/Explanations.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import styled from 'styled-components';
 import {
   AccordionHeader,
   AccordionBody,
@@ -9,6 +10,10 @@ import {
   PanelConclusion,
 } from '../../../Components';
 import { Conclusion } from '@doctorlink/traversal-core';
+
+const StyledBody = styled.div`
+  padding-top: 1.5rem;
+`;
 
 const Explanation: React.FC<{
   conclusion: Conclusion;
@@ -23,7 +28,9 @@ const Explanation: React.FC<{
         </HealthReportExplanationBody>
       </AccordionHeader>
       <AccordionBody open={open}>
-        <HealthReportExplanation conclusion={conclusion} />
+        <StyledBody>
+          <HealthReportExplanation conclusion={conclusion} />
+        </StyledBody>
       </AccordionBody>
     </PanelConclusion>
   );

--- a/packages/styled-components/src/Containers/SymptomReport/index.tsx
+++ b/packages/styled-components/src/Containers/SymptomReport/index.tsx
@@ -12,7 +12,7 @@ import {
 import { RootState } from '@doctorlink/traversal-core';
 
 export const SymptomReportConnected: React.FC<{
-  traversalId: any;
+  traversalId: string;
   chat?: boolean;
 }> = ({ traversalId, chat = false }) => {
   const getAction = chat

--- a/packages/styled-components/src/Hooks/index.ts
+++ b/packages/styled-components/src/Hooks/index.ts
@@ -5,5 +5,6 @@ export * from './useHRARoutes';
 export * from './usePrevious';
 export * from './useRestrictedList';
 export * from './useRiskSummary';
+export * from './useToggle';
 export * from './useTraversalScroll';
 export * from './useWellness';

--- a/packages/styled-components/src/Theme/base/colors.ts
+++ b/packages/styled-components/src/Theme/base/colors.ts
@@ -65,7 +65,7 @@ const colors: ColorsTheme = {
   green200: '#24a31b',
   greenyellow: '#b6ef17',
   danger: '#e42817',
-  moderate: '#ffa200',
+  moderate: '#ff7a00',
   normal: '#008000',
   chartTurquoise: '#1eddc5',
   chartPink: '#e42dad',

--- a/packages/styled-components/src/Theme/components/index.ts
+++ b/packages/styled-components/src/Theme/components/index.ts
@@ -43,6 +43,7 @@ import comparisonreporttitle, {
 } from './comparisonreporttitle';
 import summarydivider, { SummaryDividerTheme } from './summarydivider';
 import toggleassessment, { ToggleAssessmentTheme } from './toggleassessment';
+import symptomReport, { SymptomReportTheme } from './symptomReport';
 
 export interface ComponentTheme {
   algoname: AlgoNameTheme;
@@ -73,6 +74,7 @@ export interface ComponentTheme {
   radio: RadioTheme;
   summary: SummaryTheme;
   summaryDivider: SummaryDividerTheme;
+  symptomReport: SymptomReportTheme;
   tableanswercell: TableAnswerCellTheme;
   tableheadercell: TableHeaderCellTheme;
   tablerow: TableRowTheme;
@@ -110,6 +112,7 @@ const componentTheme = (baseTheme: BaseTheme): ComponentTheme => ({
   radio: radio(baseTheme),
   summary: summary(baseTheme),
   summaryDivider: summarydivider(baseTheme),
+  symptomReport: symptomReport(baseTheme),
   tableanswercell: tableanswercell(baseTheme),
   tableheadercell: tableheadercell(baseTheme),
   tablerow: tablerow(baseTheme),

--- a/packages/styled-components/src/Theme/components/panelbodytext.ts
+++ b/packages/styled-components/src/Theme/components/panelbodytext.ts
@@ -1,12 +1,14 @@
 import { BaseTheme } from '../base';
 
 export interface PanelBodyTextTheme {
+  color: string;
   fontFamily: string;
   fontSize: number;
   lineHeight: number;
 }
 
 export default (baseTheme: BaseTheme): PanelBodyTextTheme => ({
+  color: 'inherit',
   fontFamily: baseTheme.typography.fontFamily,
   fontSize: baseTheme.typography.regular.size,
   lineHeight: baseTheme.typography.regular.lineHeight,

--- a/packages/styled-components/src/Theme/components/paneltitle.ts
+++ b/packages/styled-components/src/Theme/components/paneltitle.ts
@@ -3,11 +3,13 @@ import { BaseTheme } from '../base';
 export interface PanelTitleTheme {
   fontFamily: string;
   fontSize: number;
+  fontWeight: number;
   lineHeight: number;
 }
 
 export default (baseTheme: BaseTheme): PanelTitleTheme => ({
   fontFamily: baseTheme.typography.fontFamily,
   fontSize: baseTheme.typography.title.medium.size * 1.2,
+  fontWeight: 400,
   lineHeight: baseTheme.typography.title.medium.lineHeight * 1.2,
 });

--- a/packages/styled-components/src/Theme/components/symptomReport.ts
+++ b/packages/styled-components/src/Theme/components/symptomReport.ts
@@ -3,9 +3,9 @@ import colors from '../base/colors';
 
 export interface SymptomReportTheme {
   message: {
-    backgroundNormal: string;
-    backgroundModerate: string;
-    backgroundDanger: string;
+    colorNormal: string;
+    colorModerate: string;
+    colorDanger: string;
   };
   panelHeaders: {
     textColor: string;
@@ -20,9 +20,9 @@ export interface SymptomReportTheme {
 
 export default (baseTheme: BaseTheme): SymptomReportTheme => ({
   message: {
-    backgroundNormal: baseTheme.colors.normal,
-    backgroundModerate: baseTheme.colors.moderate,
-    backgroundDanger: baseTheme.colors.danger,
+    colorNormal: baseTheme.colors.normal,
+    colorModerate: baseTheme.colors.moderate,
+    colorDanger: baseTheme.colors.danger,
   },
   panelHeaders: {
     textColor: baseTheme.colors.white,

--- a/packages/styled-components/src/Theme/components/symptomReport.ts
+++ b/packages/styled-components/src/Theme/components/symptomReport.ts
@@ -7,6 +7,13 @@ export interface SymptomReportTheme {
     colorModerate: string;
     colorDanger: string;
   };
+  messageTitle: {
+    fontSize: number;
+    fontWeight: number;
+    fontFamily: string;
+    lineHeight: number;
+    paddingBottom: number;
+  };
   panelHeaders: {
     textColor: string;
     reasonConclusions: string;
@@ -23,6 +30,13 @@ export default (baseTheme: BaseTheme): SymptomReportTheme => ({
     colorNormal: baseTheme.colors.normal,
     colorModerate: baseTheme.colors.moderate,
     colorDanger: baseTheme.colors.danger,
+  },
+  messageTitle: {
+    fontSize: baseTheme.typography.title.medium.size * 1.2,
+    fontWeight: 400,
+    fontFamily: baseTheme.typography.fontFamily,
+    lineHeight: baseTheme.typography.title.medium.lineHeight * 1.2,
+    paddingBottom: baseTheme.spacing.padding,
   },
   panelHeaders: {
     textColor: baseTheme.colors.white,

--- a/packages/styled-components/src/Theme/components/symptomReport.ts
+++ b/packages/styled-components/src/Theme/components/symptomReport.ts
@@ -1,0 +1,36 @@
+import { BaseTheme } from '../base';
+import colors from '../base/colors';
+
+export interface SymptomReportTheme {
+  message: {
+    backgroundNormal: string;
+    backgroundModerate: string;
+    backgroundDanger: string;
+  };
+  panelHeaders: {
+    textColor: string;
+    reasonConclusions: string;
+    otherConclusions: string;
+    informationConclusions: string;
+    dangerBullets: string;
+    contactBullets: string;
+    reasonBullets: string;
+  };
+}
+
+export default (baseTheme: BaseTheme): SymptomReportTheme => ({
+  message: {
+    backgroundNormal: baseTheme.colors.normal,
+    backgroundModerate: baseTheme.colors.moderate,
+    backgroundDanger: baseTheme.colors.danger,
+  },
+  panelHeaders: {
+    textColor: baseTheme.colors.white,
+    reasonConclusions: colors.brand100,
+    otherConclusions: colors.brand100,
+    informationConclusions: colors.brand100,
+    dangerBullets: colors.danger,
+    contactBullets: colors.moderate,
+    reasonBullets: colors.lightBlue100,
+  },
+});

--- a/packages/traversal-core/package-lock.json
+++ b/packages/traversal-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-core",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/traversal-core/package.json
+++ b/packages/traversal-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-core",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Doctorlink traversal core package",
   "author": "DoctorLink Team <ben.redmond-benham@doctorlink.com>",
   "homepage": "https://github.com/DoctorLink/npm#readme",

--- a/packages/traversal-core/src/Models/Conclusion.ts
+++ b/packages/traversal-core/src/Models/Conclusion.ts
@@ -20,7 +20,10 @@ export interface NumberConclusion extends Conclusion {
 export interface ConclusionBullet {
   bulletId: number;
   bulletUniqueId: number;
+  conclusionId: number;
   displayText: string;
+  priority: number;
+  category2: string;
 }
 
 export interface SymptomReportModel {

--- a/packages/traversal-core/src/Models/Conclusion.ts
+++ b/packages/traversal-core/src/Models/Conclusion.ts
@@ -8,6 +8,7 @@ export interface Conclusion {
   subCategory: string;
   explanation: string;
   moreDetail: string;
+  truncated: string;
   bullets: ConclusionBullet[];
 }
 
@@ -22,8 +23,33 @@ export interface ConclusionBullet {
   displayText: string;
 }
 
+export interface SymptomReportModel {
+  highestPriority: number;
+  symptomConclusions: Conclusion[];
+  reasonConclusionTitle: string;
+  reasonConclusions: Conclusion[];
+  otherConclusionTitle: string;
+  otherConclusions: Conclusion[];
+  informationConclusionTitle: string;
+  informationConclusions: Conclusion[];
+  contactBulletTitle: string;
+  contactBullets: ConclusionBullet[];
+  dangerBulletTitle: string;
+  dangerBullets: ConclusionBullet[];
+  reasonBulletTitle: string;
+  reasonBullets: ConclusionBullet[];
+  mainBullets: ConclusionBullet[];
+  reasonCategory: string;
+  reasonSubCat1: string;
+  reasonDisposition: string;
+  messageTitle: string;
+  messageLevel: number;
+  messageDescription: string;
+  reasonTimeInMinutes: number;
+}
+
 export interface ConclusionModel {
   traversalId?: string;
   conclusions?: Array<Conclusion>;
-  symptomReport?: any;
+  symptomReport?: SymptomReportModel;
 }

--- a/packages/traversal-embed/package.json
+++ b/packages/traversal-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-embed",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Doctorlink's embeded traversal client",
   "keywords": [
     "doctorlink",
@@ -33,8 +33,8 @@
     "serve": "npm run build && serve ."
   },
   "dependencies": {
-    "@doctorlink/styled-components": "^0.8.3",
-    "@doctorlink/traversal-core": "^0.8.3",
-    "@doctorlink/traversal-redux": "^0.8.3"
+    "@doctorlink/styled-components": "^0.8.4",
+    "@doctorlink/traversal-core": "^0.8.4",
+    "@doctorlink/traversal-redux": "^0.8.4"
   }
 }

--- a/packages/traversal-redux/package-lock.json
+++ b/packages/traversal-redux/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-redux",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/traversal-redux/package.json
+++ b/packages/traversal-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-redux",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Doctorlink traversal redux package",
   "author": "DoctorLink Team <ben.redmond-benham@doctorlink.com>",
   "homepage": "https://github.com/DoctorLink/npm#readme",
@@ -31,7 +31,7 @@
     "test": "tsc --noEmit && jest test"
   },
   "dependencies": {
-    "@doctorlink/traversal-core": "^0.8.3",
+    "@doctorlink/traversal-core": "^0.8.4",
     "axios": "^0.19.2",
     "normalizr": "^3.6.0",
     "redux": "^4.0.5",


### PR DESCRIPTION
Redesign of the symptom report page:
- collapsible, full-width panels
- new design for the top-level message
- bulleted lists, including a custom 'warning triangle' bullet for danger bullets
- theming to allow further customisation in the app

Plus refactoring and strong typing.