### PR TITLE
#1765: Missing health age explanation

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.8.4"
+  "version": "0.8.5"
 }

--- a/packages/styled-components/package-lock.json
+++ b/packages/styled-components/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@doctorlink/styled-components",
-	"version": "0.8.4",
+	"version": "0.8.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/styled-components",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Doctorlink styled components",
   "keywords": [
     "styled-components"
@@ -34,8 +34,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@doctorlink/traversal-core": "^0.8.4",
-    "@doctorlink/traversal-redux": "^0.8.4",
+    "@doctorlink/traversal-core": "^0.8.5",
+    "@doctorlink/traversal-redux": "^0.8.5",
     "@types/react-redux": "^7.1.9",
     "@types/react-responsive": "^8.0.2",
     "@types/react-router-dom": "^5.1.5",

--- a/packages/traversal-core/package-lock.json
+++ b/packages/traversal-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-core",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/traversal-core/package.json
+++ b/packages/traversal-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-core",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Doctorlink traversal core package",
   "author": "DoctorLink Team <ben.redmond-benham@doctorlink.com>",
   "homepage": "https://github.com/DoctorLink/npm#readme",

--- a/packages/traversal-embed/package.json
+++ b/packages/traversal-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-embed",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Doctorlink's embeded traversal client",
   "keywords": [
     "doctorlink",
@@ -33,8 +33,8 @@
     "serve": "npm run build && serve ."
   },
   "dependencies": {
-    "@doctorlink/styled-components": "^0.8.4",
-    "@doctorlink/traversal-core": "^0.8.4",
-    "@doctorlink/traversal-redux": "^0.8.4"
+    "@doctorlink/styled-components": "^0.8.5",
+    "@doctorlink/traversal-core": "^0.8.5",
+    "@doctorlink/traversal-redux": "^0.8.5"
   }
 }

--- a/packages/traversal-redux/package-lock.json
+++ b/packages/traversal-redux/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-redux",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/traversal-redux/package.json
+++ b/packages/traversal-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctorlink/traversal-redux",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Doctorlink traversal redux package",
   "author": "DoctorLink Team <ben.redmond-benham@doctorlink.com>",
   "homepage": "https://github.com/DoctorLink/npm#readme",
@@ -31,7 +31,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@doctorlink/traversal-core": "^0.8.4",
+    "@doctorlink/traversal-core": "^0.8.5",
     "axios": "^0.19.2",
     "normalizr": "^3.6.0",
     "redux": "^4.0.5",

--- a/packages/traversal-redux/src/Selectors/XmlRules.ts
+++ b/packages/traversal-redux/src/Selectors/XmlRules.ts
@@ -24,8 +24,8 @@ export class XmlRules {
     );
   }
 
-  getRuleValue(comparisonValue: number = +this.value): string | null {
-    if (!comparisonValue) return null;
+  getRuleValue(comparisonValue: number | string = this.value): string | null {
+    if (!comparisonValue && comparisonValue !== 0) return null;
 
     const matchingRule = this.rules.find((rule) => {
       const withinLowerBound = rule.low === null || rule.low <= comparisonValue;

--- a/packages/traversal-redux/src/Selectors/XmlRules.ts
+++ b/packages/traversal-redux/src/Selectors/XmlRules.ts
@@ -1,31 +1,38 @@
+interface Rule {
+  high: number | null;
+  low: number | null;
+  value: string;
+}
+
 export class XmlRules {
-  value: any;
-  rules: any;
+  value: string;
+  rules: Rule[];
   constructor(xml: string) {
     const parser = new DOMParser();
     const element = parser.parseFromString(xml, 'text/xml').documentElement;
-    this.value = element.getAttribute('value');
+    this.value = element.getAttribute('value') as string;
     this.rules = Array.from(element.getElementsByTagName('rule')).map(
-      (rule) => ({
-        high: rule.getAttribute('high'),
-        low: rule.getAttribute('low'),
-        value: rule.innerHTML,
-      })
+      (rule) => {
+        const high = rule.getAttribute('high');
+        const low = rule.getAttribute('low');
+        return {
+          high: (high && Number(high)) || null,
+          low: (low && Number(low)) || null,
+          value: rule.innerHTML,
+        };
+      }
     );
   }
 
-  getRuleValue(comparisonValue = this.value) {
-    if (!comparisonValue) return undefined;
+  getRuleValue(comparisonValue: number = +this.value): string | null {
+    if (!comparisonValue) return null;
 
-    const matchingRule = this.rules.find(
-      (rule: { low: number | null; high: number | null }) => {
-        const withinLowerBound =
-          rule.low === null || rule.low <= comparisonValue;
-        const withinUpperBound =
-          rule.high === null || rule.high > comparisonValue;
-        return withinLowerBound && withinUpperBound;
-      }
-    );
-    return matchingRule && matchingRule.value;
+    const matchingRule = this.rules.find((rule) => {
+      const withinLowerBound = rule.low === null || rule.low <= comparisonValue;
+      const withinUpperBound =
+        rule.high === null || rule.high > comparisonValue;
+      return withinLowerBound && withinUpperBound;
+    });
+    return matchingRule?.value ?? null;
   }
 }

--- a/packages/traversal-redux/src/Selectors/parseNumberConclusion.ts
+++ b/packages/traversal-redux/src/Selectors/parseNumberConclusion.ts
@@ -8,6 +8,6 @@ export function parseNumberConclusion(
   return {
     ...conclusion,
     value: xmlRules.value || '?',
-    color: xmlRules.getRuleValue(xmlRules.value),
+    color: xmlRules.getRuleValue() as string,
   };
 }

--- a/packages/traversal-redux/test/Selectors/healthAssessments.test.ts
+++ b/packages/traversal-redux/test/Selectors/healthAssessments.test.ts
@@ -9,6 +9,7 @@ describe('health assessment selectors', () => {
       ${45}     | ${'Somewhat better'}
       ${48}     | ${'Somewhat better'}
       ${49}     | ${'Around average'}
+      ${50}     | ${'Around average'}
       ${51}     | ${'Around average'}
       ${52}     | ${'Somewhat worse'}
       ${55}     | ${'Somewhat worse'}

--- a/packages/traversal-redux/test/Selectors/parseNumberConclusion.test.ts
+++ b/packages/traversal-redux/test/Selectors/parseNumberConclusion.test.ts
@@ -40,4 +40,32 @@ describe('parseNumberConclusion', () => {
 
     expect(parsed.value).toBe('?');
   });
+
+  test.each`
+    value   | color
+    ${''}   | ${null}
+    ${18.4} | ${'red'}
+    ${18.5} | ${'yellow'}
+    ${19}   | ${'green'}
+    ${25}   | ${'green'}
+    ${26}   | ${'yellow'}
+    ${31}   | ${'red'}
+  `('Returns correct color $color for value $value', ({ value, color }) => {
+    const conclusion = {
+      displayText: 'BMI',
+      category1: 'My Numbers',
+      moreDetail: `
+            <data name="BMI" value="${value}">
+                <rule high="18.5">red</rule>
+                <rule low="30">red</rule>
+                <rule low="25.1" high="30">yellow</rule>
+                <rule low="18.5" high="19">yellow</rule>
+                <rule ideal="true" low="19" high="25.1">green</rule>
+           </data>`,
+    } as Conclusion;
+
+    const parsed = parseNumberConclusion(conclusion);
+
+    expect(parsed.color).toBe(color);
+  });
 });


### PR DESCRIPTION
Fix bug where the health age explanation disappears if the health age is equal to the real age.

Also add typings and some extra tests for other code affected by this change.